### PR TITLE
Feat/redo str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc41b65e01b6851bdcd2d741824e6b310d571396bf3915e31e4792034ee65126"
+
+[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,79 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40db657cc67a8dd9fe4b40db5b73027f5f224623545597e1930cbbb9c05b1de5"
+checksum = "df8e52f9236eb722da0990a70bbb1216dcc7a77bcb00c63439d2d982823e90d5"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -1258,26 +1191,30 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50c63db77f846ac5119477422f0156f0a1826ceaae7d921f9a6d5ea5f7ca3"
+checksum = "dd503430a6d9779b07915d858865fe998317ef3cfef8973881f578ac5d4baae7"
 dependencies = [
  "ahash",
  "arrow-format",
+ "atoi_simd",
  "bytemuck",
  "chrono",
  "dyn-clone",
  "either",
  "ethnum",
+ "fast-float",
  "foreign_vec",
  "getrandom",
  "hashbrown",
- "lexical-core",
+ "itoa",
  "lz4",
  "multiversion",
  "num-traits",
  "polars-error",
+ "polars-utils",
  "rustc_version 0.4.0",
+ "ryu",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
@@ -1286,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb622b8ca81b4614c64d95e7590d6e0571d7d398b5ad595c1abc4412abe714"
+checksum = "ae73d5b8e55decde670caba1cc82b61f14bfb9a72503198f0997d657a98dcfd6"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -1317,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6480520ebde0b20935b600483b865513891e36c04942cebdd19e4f338257b4"
+checksum = "eb0520d68eaa9993ae0c741409d1526beff5b8f48e1d73e4381616f8152cf488"
 dependencies = [
  "arrow-format",
  "regex",
@@ -1329,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ffi"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30a438ed19cf5259532b945af499c069e7e2f01e88f2a71e587b5f55c8253e4"
+checksum = "448e0c12efea3fc8c291681d07708285930c190fbb313735c09e8de0a4c6950f"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -1339,17 +1276,17 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666466a3b151047c76d99b4e4e5f5438895ef97848008cf49b06df8e3d2d395a"
+checksum = "96e10a0745acd6009db64bef0ceb9e23a70b1c27b26a0a6517c91f3e6363bc06"
 dependencies = [
  "ahash",
+ "atoi_simd",
  "bytes",
  "chrono",
  "fast-float",
  "home",
  "itoa",
- "lexical",
  "memchr",
  "memmap2",
  "num-traits",
@@ -1369,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e1c2da1ca20106f80d9510090344e7311fd1dcfd6e6b65031e10606c0958c7"
+checksum = "3555f759705be6dd0d3762d16a0b8787b2dc4da73b57465f3b2bf1a070ba8f20"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -1392,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe2d37a6a3ef358499d43aecee80740e62dd44e6cfe7a9c4aa0b8db88de8292"
+checksum = "1a7eb218296aaa7f79945f08288ca32ca3cf25fa505649eeee689ec21eebf636"
 dependencies = [
  "ahash",
  "argminmax",
@@ -1416,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6aa050d529be01617f54bc60658149da76f97dbea9fdac3c9d60b811f64a2ba"
+checksum = "66094e7df64c932a9a7bdfe7df0c65efdcb192096e11a6a765a9778f78b4bdec"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -1439,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47e5d62d8f612aab61a6331d04c5c95c9ff301106d8b91131c8833b4ef3def6"
+checksum = "10e32a0958ef854b132bad7f8369cb3237254635d5e864c99505bc0bc1035fbc"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1462,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05d6544f7d6065fcaa93bc69aac0532ce09aab4f81ec03c9a78dd901bb0c05b"
+checksum = "d135ab81cac2906ba74ea8984c7e6025d081ae5867615bcefb4d84dfdb456dac"
 dependencies = [
  "polars-arrow",
  "polars-error",
@@ -1473,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f65f9c8bfe7f0b2c08c38c79b92ec4ddaf213fc424d94a6272ed7b2d83987f"
+checksum = "b8dbd7786849a5e3ad1fde188bf38141632f626e3a57319b0bbf7a5f1d75519e"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -1490,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763af36aeeb85ef083f11c43bc28c5b6222e2aae039c5118d916bc855f2b5b9"
+checksum = "aae56f79e9cedd617773c1c8f5ca84a31a8b1d593714959d5f799e7bdd98fe51"
 dependencies = [
  "atoi",
  "chrono",
@@ -1509,13 +1446,14 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.34.2"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d2c038ff67e4eb6019682c3f66d83f744e285de9c28e816109a61bace824cd"
+checksum = "da6ce68169fe61d46958c8eab7447360f30f2f23f6e24a0ce703a14b0a3cfbfc"
 dependencies = [
  "ahash",
  "bytemuck",
  "hashbrown",
+ "indexmap",
  "num-traits",
  "once_cell",
  "polars-error",
@@ -1643,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23285549e989e130270998b3f0a30ba8c081055fe130e066f46f214dce7cc3"
+checksum = "e37da190c68036cb620bbde9a8933839addfa4b66e9903b9b1dc751b2b00e7d7"
 dependencies = [
  "polars",
  "polars-core",
@@ -1660,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239e3eafc15ddcec5e62e76ac0b208718e00565d346f5e0448da409a335341e3"
+checksum = "83a39639843d80428b6b724a294a7876b395f9ec313bc66a011b30b11d19e8ef"
 dependencies = [
  "polars-core",
  "polars-ffi",
@@ -2084,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272b7bb0a225320170c99901b4b5fb3a4384e255a7f2cc228f61e2ba3893e75"
+checksum = "743b4dc2cbde11890ccb254a8fc9d537fa41b36da00de2a1c5e9848c9bc42bd7"
 dependencies = [
  "log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
 name = "polars_ds"
 version = "0.1.1"
 dependencies = [
+ "aho-corasick",
  "faer",
  "hashbrown",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "polars_ds"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aho-corasick",
  "faer",
@@ -1541,6 +1541,7 @@ dependencies = [
  "pyo3",
  "pyo3-polars",
  "rustfft",
+ "strsim",
 ]
 
 [[package]]
@@ -2107,6 +2108,12 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = {version = "0.20", features = ["extension-module"]}
 pyo3-polars = {version = "0.8", features = ["derive"]}
-polars = {version = "0.34", features = ["performant", "chunked_ids", "diff","lazy","dtype-struct", "ndarray", "log", "nightly"]}
+polars = {version = "0.34", features = ["performant", "chunked_ids", "diff","lazy","dtype-struct", "dtype-array", "ndarray", "log", "nightly"]}
 num = "0.4.1"
 faer = {version = "0.15", features = ["ndarray", "nightly"]}
 ndarray = "0.15.6"
 hashbrown = {version = "0.14.2", features=["nightly"]}
 rustfft = "6.1.0"
 itertools = "0.12.0"
+aho-corasick = "1.1.2"
 # rv = "0.16.0"
 # argminmax = {version = "0.6.1", features = ["float", "nightly_simd"]}
  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_ds"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = {version = "0.20", features = ["extension-module"]}
 pyo3-polars = {version = "0.8", features = ["derive"]}
-polars = {version = "0.34", features = ["performant", "chunked_ids", "diff","lazy","dtype-struct", "dtype-array", "ndarray", "log", "nightly"]}
+polars = {version = "0.34", features = ["performant", "diff", "lazy", "dtype-array", "ndarray", "log", "nightly"]}
 num = "0.4.1"
 faer = {version = "0.15", features = ["ndarray", "nightly"]}
 ndarray = "0.15.6"
@@ -20,8 +20,8 @@ hashbrown = {version = "0.14.2", features=["nightly"]}
 rustfft = "6.1.0"
 itertools = "0.12.0"
 aho-corasick = "1.1.2"
-# rv = "0.16.0"
-# argminmax = {version = "0.6.1", features = ["float", "nightly_simd"]}
+strsim = "0.10.0"
+
  
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = {version = "0.20", features = ["extension-module"]}
-pyo3-polars = {version = "0.8", features = ["derive"]}
-polars = {version = "0.34", features = ["performant", "diff", "lazy", "dtype-array", "ndarray", "log", "nightly"]}
+pyo3-polars = {version = "0.9", features = ["derive"]}
+polars = {version = "0.35.4", features = ["performant", "diff", "lazy", "dtype-array", "ndarray", "log", "nightly"]}
 num = "0.4.1"
 faer = {version = "0.15", features = ["ndarray", "nightly"]}
 ndarray = "0.15.6"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Polars Extension for General Data Science Use
 
+A Polars Plugin aiming to simplify common numerical/string data analysis procedures. 
+
 **Currently in Alpha. Feel free to submit feature requests in the issues section of the repo.**
 
 The goal for this package is to provide data scientists/analysts/engineers/quants more tools to manipulate, transform, and make sense of data, without the need to leave DataFrame land (aka Wonderland).
@@ -80,6 +82,10 @@ The package right now contains two extensions:
 ## Other Extensions ?
 
 More stats, clustering, etc. It is simply a matter of willingness and market demand.
+
+## Future Plans
+
+I am open to make this package a Python frontend for other machine learning processes/models with Rust packages at the backend. There are some very interesting packages to incorporate, such as k-medoids. But I do want to stick with Faer as a Rust linear algebra backend and I do want to keep it simple for now.
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The package right now contains two extensions:
 3. Common loss functions, e.g. L1, L2, L infinity, huber loss, MAPE, SMAPE, wMAPE, etc.
 4. Common mini-models, lstsq, condition entropy. 
 5. Discrete Fourier Transform, returning the real and complex part of the new series.
+6. ROC AUC, precision, recall, F, average precision, all as expressions.
 
 
 ## String Extension
@@ -70,19 +71,15 @@ The package right now contains two extensions:
 1. Levenshtein distance, Hamming distance, str Jaccard similarity
 2. Simple Tokenize
 3. Stemming (Right now only Snowball stemmer for English)
+4. Frequency based merging, inferral, and removal.
 
 ### Todo list
 
-1. Longest common subsequence as string distance metric
-2. Vectorizers (Count + TFIDF)?
-3. Similarity version of the distances, and more variations and parameters.
+1. Aho-Corasick string search https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm
 
 ## Other Extensions ?
 
-E.g. stats_ext, dist_ext (L^p distance for vectors (scalar version is implemented) etc.) etc.
-
-Simple unsupervised clusters can also be done. It is simply a matter of willingness and market demand.
-
+More stats, clustering, etc. It is simply a matter of willingness and market demand.
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ The package right now contains two extensions:
 
 ### Existing Features
 
-1. Levenshtein distance, Hamming distance, str Jaccard similarity
-2. Simple Tokenize
-3. Stemming (Right now only Snowball stemmer for English)
-4. Frequency based merging, inferral, and removal.
+1. Levenshtein distance + similarity, Hamming distance, Jaro similarity, Str Jaccard simiarlity, Sorensen dice similarity, overlap coefficient
+2. Simple tokenize, snowball stemming,
+3. Frequency based merging, inferral, and removal.
+4. Aho-Corasick matching, replacing multiple patterns.
 
-### Todo list
+## Plans?
 
-1. Aho-Corasick string search https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm
+1. Some more string similarity like: https://www.postgresql.org/docs/9.1/pgtrgm.html
 
 ## Other Extensions ?
 
@@ -86,6 +86,8 @@ More stats, clustering, etc. It is simply a matter of willingness and market dem
 ## Future Plans
 
 I am open to make this package a Python frontend for other machine learning processes/models with Rust packages at the backend. There are some very interesting packages to incorporate, such as k-medoids. But I do want to stick with Faer as a Rust linear algebra backend and I do want to keep it simple for now.
+
+Right now most str similarity/dist is dependent on the strsim crate, which is no longer maintained and has some very old code. The current plan is to keep it for now and maybe replace it with higher performance code later (if there is the need to do so). 
 
 # Disclaimer
 

--- a/examples/basics.ipynb
+++ b/examples/basics.ipynb
@@ -36,7 +36,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>f</th><th>dummy</th><th>a</th><th>b</th><th>x1</th><th>x2</th><th>y</th><th>actual</th><th>predicted</th><th>dummy_groups</th></tr><tr><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>i64</td><td>i32</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>0.0</td><td>&quot;a&quot;</td><td>0.964315</td><td>0.957721</td><td>0</td><td>100000</td><td>-100000</td><td>1</td><td>0.815745</td><td>&quot;a&quot;</td></tr><tr><td>0.841471</td><td>&quot;a&quot;</td><td>0.887518</td><td>0.472714</td><td>1</td><td>100001</td><td>-99999</td><td>1</td><td>0.077396</td><td>&quot;a&quot;</td></tr><tr><td>0.909297</td><td>&quot;a&quot;</td><td>0.900286</td><td>0.811882</td><td>2</td><td>100002</td><td>-99998</td><td>0</td><td>0.691992</td><td>&quot;a&quot;</td></tr><tr><td>0.14112</td><td>&quot;a&quot;</td><td>0.552239</td><td>0.375525</td><td>3</td><td>100003</td><td>-99997</td><td>0</td><td>0.781911</td><td>&quot;a&quot;</td></tr><tr><td>-0.756802</td><td>&quot;a&quot;</td><td>0.710553</td><td>0.687387</td><td>4</td><td>100004</td><td>-99996</td><td>1</td><td>0.671779</td><td>&quot;a&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (5, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>f</th><th>dummy</th><th>a</th><th>b</th><th>x1</th><th>x2</th><th>y</th><th>actual</th><th>predicted</th><th>dummy_groups</th></tr><tr><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>i64</td><td>i32</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>0.0</td><td>&quot;a&quot;</td><td>0.931976</td><td>0.499952</td><td>0</td><td>100000</td><td>-100000</td><td>0</td><td>0.184311</td><td>&quot;a&quot;</td></tr><tr><td>0.841471</td><td>&quot;a&quot;</td><td>0.866541</td><td>0.637585</td><td>1</td><td>100001</td><td>-99999</td><td>0</td><td>0.269849</td><td>&quot;a&quot;</td></tr><tr><td>0.909297</td><td>&quot;a&quot;</td><td>0.913402</td><td>0.610963</td><td>2</td><td>100002</td><td>-99998</td><td>0</td><td>0.647687</td><td>&quot;a&quot;</td></tr><tr><td>0.14112</td><td>&quot;a&quot;</td><td>0.879696</td><td>0.161823</td><td>3</td><td>100003</td><td>-99997</td><td>0</td><td>0.080473</td><td>&quot;a&quot;</td></tr><tr><td>-0.756802</td><td>&quot;a&quot;</td><td>0.468613</td><td>0.494642</td><td>4</td><td>100004</td><td>-99996</td><td>1</td><td>0.703064</td><td>&quot;a&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 10)\n",
@@ -45,11 +45,11 @@
        "│ ---       ┆ ---   ┆ ---      ┆ ---      ┆   ┆ ---     ┆ ---    ┆ ---       ┆ ---          │\n",
        "│ f64       ┆ str   ┆ f64      ┆ f64      ┆   ┆ i64     ┆ i32    ┆ f64       ┆ str          │\n",
        "╞═══════════╪═══════╪══════════╪══════════╪═══╪═════════╪════════╪═══════════╪══════════════╡\n",
-       "│ 0.0       ┆ a     ┆ 0.964315 ┆ 0.957721 ┆ … ┆ -100000 ┆ 1      ┆ 0.815745  ┆ a            │\n",
-       "│ 0.841471  ┆ a     ┆ 0.887518 ┆ 0.472714 ┆ … ┆ -99999  ┆ 1      ┆ 0.077396  ┆ a            │\n",
-       "│ 0.909297  ┆ a     ┆ 0.900286 ┆ 0.811882 ┆ … ┆ -99998  ┆ 0      ┆ 0.691992  ┆ a            │\n",
-       "│ 0.14112   ┆ a     ┆ 0.552239 ┆ 0.375525 ┆ … ┆ -99997  ┆ 0      ┆ 0.781911  ┆ a            │\n",
-       "│ -0.756802 ┆ a     ┆ 0.710553 ┆ 0.687387 ┆ … ┆ -99996  ┆ 1      ┆ 0.671779  ┆ a            │\n",
+       "│ 0.0       ┆ a     ┆ 0.931976 ┆ 0.499952 ┆ … ┆ -100000 ┆ 0      ┆ 0.184311  ┆ a            │\n",
+       "│ 0.841471  ┆ a     ┆ 0.866541 ┆ 0.637585 ┆ … ┆ -99999  ┆ 0      ┆ 0.269849  ┆ a            │\n",
+       "│ 0.909297  ┆ a     ┆ 0.913402 ┆ 0.610963 ┆ … ┆ -99998  ┆ 0      ┆ 0.647687  ┆ a            │\n",
+       "│ 0.14112   ┆ a     ┆ 0.879696 ┆ 0.161823 ┆ … ┆ -99997  ┆ 0      ┆ 0.080473  ┆ a            │\n",
+       "│ -0.756802 ┆ a     ┆ 0.468613 ┆ 0.494642 ┆ … ┆ -99996  ┆ 1      ┆ 0.703064  ┆ a            │\n",
        "└───────────┴───────┴──────────┴──────────┴───┴─────────┴────────┴───────────┴──────────────┘"
       ]
      },
@@ -394,17 +394,17 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>f64</td></tr></thead><tbody><tr><td>1.095289</td></tr></tbody></table></div>"
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>f64</td></tr></thead><tbody><tr><td>-1.051362</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 1)\n",
-       "┌──────────┐\n",
-       "│ a        │\n",
-       "│ ---      │\n",
-       "│ f64      │\n",
-       "╞══════════╡\n",
-       "│ 1.095289 │\n",
-       "└──────────┘"
+       "┌───────────┐\n",
+       "│ a         │\n",
+       "│ ---       │\n",
+       "│ f64       │\n",
+       "╞═══════════╡\n",
+       "│ -1.051362 │\n",
+       "└───────────┘"
       ]
      },
      "execution_count": 11,
@@ -434,17 +434,17 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>list[f64]</td></tr></thead><tbody><tr><td>[1.095289, 199997.987217]</td></tr></tbody></table></div>"
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>list[f64]</td></tr></thead><tbody><tr><td>[-1.051362, 199997.888517]</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 1)\n",
-       "┌───────────────────────────┐\n",
-       "│ a                         │\n",
-       "│ ---                       │\n",
-       "│ list[f64]                 │\n",
-       "╞═══════════════════════════╡\n",
-       "│ [1.095289, 199997.987217] │\n",
-       "└───────────────────────────┘"
+       "┌────────────────────────────┐\n",
+       "│ a                          │\n",
+       "│ ---                        │\n",
+       "│ list[f64]                  │\n",
+       "╞════════════════════════════╡\n",
+       "│ [-1.051362, 199997.888517] │\n",
+       "└────────────────────────────┘"
       ]
      },
      "execution_count": 12,
@@ -474,7 +474,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy</th><th>t</th></tr><tr><td>str</td><td>f64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>-145.993356</td></tr><tr><td>&quot;b&quot;</td><td>-146.500699</td></tr></tbody></table></div>"
+       "<small>shape: (2, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy</th><th>t</th></tr><tr><td>str</td><td>f64</td></tr></thead><tbody><tr><td>&quot;b&quot;</td><td>-146.913633</td></tr><tr><td>&quot;a&quot;</td><td>-146.590267</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2, 2)\n",
@@ -483,8 +483,8 @@
        "│ ---   ┆ ---         │\n",
        "│ str   ┆ f64         │\n",
        "╞═══════╪═════════════╡\n",
-       "│ a     ┆ -145.993356 │\n",
-       "│ b     ┆ -146.500699 │\n",
+       "│ b     ┆ -146.913633 │\n",
+       "│ a     ┆ -146.590267 │\n",
        "└───────┴─────────────┘"
       ]
      },
@@ -515,7 +515,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy_groups</th><th>l2</th><th>log loss</th><th>roc_auc</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>0.335195</td><td>1.005967</td><td>0.496666</td></tr><tr><td>&quot;b&quot;</td><td>0.333368</td><td>1.000849</td><td>0.499404</td></tr></tbody></table></div>"
+       "<small>shape: (2, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy_groups</th><th>l2</th><th>log loss</th><th>roc_auc</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>0.329846</td><td>0.98835</td><td>0.506765</td></tr><tr><td>&quot;b&quot;</td><td>0.333061</td><td>0.998663</td><td>0.500226</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2, 4)\n",
@@ -524,8 +524,8 @@
        "│ ---          ┆ ---      ┆ ---      ┆ ---      │\n",
        "│ str          ┆ f64      ┆ f64      ┆ f64      │\n",
        "╞══════════════╪══════════╪══════════╪══════════╡\n",
-       "│ a            ┆ 0.335195 ┆ 1.005967 ┆ 0.496666 │\n",
-       "│ b            ┆ 0.333368 ┆ 1.000849 ┆ 0.499404 │\n",
+       "│ a            ┆ 0.329846 ┆ 0.98835  ┆ 0.506765 │\n",
+       "│ b            ┆ 0.333061 ┆ 0.998663 ┆ 0.500226 │\n",
        "└──────────────┴──────────┴──────────┴──────────┘"
       ]
      },
@@ -613,7 +613,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;to&quot;</td></tr><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;going&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;going&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;to&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 1)\n",
@@ -622,11 +622,11 @@
        "│ ---    │\n",
        "│ str    │\n",
        "╞════════╡\n",
-       "│ to     │\n",
-       "│ world  │\n",
-       "│ hello  │\n",
-       "│ church │\n",
        "│ going  │\n",
+       "│ hello  │\n",
+       "│ world  │\n",
+       "│ church │\n",
+       "│ to     │\n",
        "└────────┘"
       ]
      },
@@ -658,7 +658,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;go&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;go&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 1)\n",
@@ -667,9 +667,9 @@
        "│ ---    │\n",
        "│ str    │\n",
        "╞════════╡\n",
+       "│ world  │\n",
        "│ church │\n",
        "│ hello  │\n",
-       "│ world  │\n",
        "│ go     │\n",
        "└────────┘"
       ]

--- a/examples/basics.ipynb
+++ b/examples/basics.ipynb
@@ -36,7 +36,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>f</th><th>dummy</th><th>a</th><th>b</th><th>x1</th><th>x2</th><th>y</th><th>actual</th><th>predicted</th><th>dummy_groups</th></tr><tr><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>i64</td><td>i32</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>0.0</td><td>&quot;a&quot;</td><td>0.931976</td><td>0.499952</td><td>0</td><td>100000</td><td>-100000</td><td>0</td><td>0.184311</td><td>&quot;a&quot;</td></tr><tr><td>0.841471</td><td>&quot;a&quot;</td><td>0.866541</td><td>0.637585</td><td>1</td><td>100001</td><td>-99999</td><td>0</td><td>0.269849</td><td>&quot;a&quot;</td></tr><tr><td>0.909297</td><td>&quot;a&quot;</td><td>0.913402</td><td>0.610963</td><td>2</td><td>100002</td><td>-99998</td><td>0</td><td>0.647687</td><td>&quot;a&quot;</td></tr><tr><td>0.14112</td><td>&quot;a&quot;</td><td>0.879696</td><td>0.161823</td><td>3</td><td>100003</td><td>-99997</td><td>0</td><td>0.080473</td><td>&quot;a&quot;</td></tr><tr><td>-0.756802</td><td>&quot;a&quot;</td><td>0.468613</td><td>0.494642</td><td>4</td><td>100004</td><td>-99996</td><td>1</td><td>0.703064</td><td>&quot;a&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (5, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>f</th><th>dummy</th><th>a</th><th>b</th><th>x1</th><th>x2</th><th>y</th><th>actual</th><th>predicted</th><th>dummy_groups</th></tr><tr><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>i64</td><td>i64</td><td>i64</td><td>i32</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>0.0</td><td>&quot;a&quot;</td><td>0.885027</td><td>0.882198</td><td>0</td><td>100000</td><td>-100000</td><td>0</td><td>0.496191</td><td>&quot;a&quot;</td></tr><tr><td>0.841471</td><td>&quot;a&quot;</td><td>0.650153</td><td>0.412553</td><td>1</td><td>100001</td><td>-99999</td><td>0</td><td>0.484822</td><td>&quot;a&quot;</td></tr><tr><td>0.909297</td><td>&quot;a&quot;</td><td>0.371058</td><td>0.566292</td><td>2</td><td>100002</td><td>-99998</td><td>1</td><td>0.500862</td><td>&quot;a&quot;</td></tr><tr><td>0.14112</td><td>&quot;a&quot;</td><td>0.685015</td><td>0.200661</td><td>3</td><td>100003</td><td>-99997</td><td>1</td><td>0.056418</td><td>&quot;a&quot;</td></tr><tr><td>-0.756802</td><td>&quot;a&quot;</td><td>0.495579</td><td>0.567158</td><td>4</td><td>100004</td><td>-99996</td><td>0</td><td>0.829329</td><td>&quot;a&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 10)\n",
@@ -45,11 +45,11 @@
        "│ ---       ┆ ---   ┆ ---      ┆ ---      ┆   ┆ ---     ┆ ---    ┆ ---       ┆ ---          │\n",
        "│ f64       ┆ str   ┆ f64      ┆ f64      ┆   ┆ i64     ┆ i32    ┆ f64       ┆ str          │\n",
        "╞═══════════╪═══════╪══════════╪══════════╪═══╪═════════╪════════╪═══════════╪══════════════╡\n",
-       "│ 0.0       ┆ a     ┆ 0.931976 ┆ 0.499952 ┆ … ┆ -100000 ┆ 0      ┆ 0.184311  ┆ a            │\n",
-       "│ 0.841471  ┆ a     ┆ 0.866541 ┆ 0.637585 ┆ … ┆ -99999  ┆ 0      ┆ 0.269849  ┆ a            │\n",
-       "│ 0.909297  ┆ a     ┆ 0.913402 ┆ 0.610963 ┆ … ┆ -99998  ┆ 0      ┆ 0.647687  ┆ a            │\n",
-       "│ 0.14112   ┆ a     ┆ 0.879696 ┆ 0.161823 ┆ … ┆ -99997  ┆ 0      ┆ 0.080473  ┆ a            │\n",
-       "│ -0.756802 ┆ a     ┆ 0.468613 ┆ 0.494642 ┆ … ┆ -99996  ┆ 1      ┆ 0.703064  ┆ a            │\n",
+       "│ 0.0       ┆ a     ┆ 0.885027 ┆ 0.882198 ┆ … ┆ -100000 ┆ 0      ┆ 0.496191  ┆ a            │\n",
+       "│ 0.841471  ┆ a     ┆ 0.650153 ┆ 0.412553 ┆ … ┆ -99999  ┆ 0      ┆ 0.484822  ┆ a            │\n",
+       "│ 0.909297  ┆ a     ┆ 0.371058 ┆ 0.566292 ┆ … ┆ -99998  ┆ 1      ┆ 0.500862  ┆ a            │\n",
+       "│ 0.14112   ┆ a     ┆ 0.685015 ┆ 0.200661 ┆ … ┆ -99997  ┆ 1      ┆ 0.056418  ┆ a            │\n",
+       "│ -0.756802 ┆ a     ┆ 0.495579 ┆ 0.567158 ┆ … ┆ -99996  ┆ 0      ┆ 0.829329  ┆ a            │\n",
        "└───────────┴───────┴──────────┴──────────┴───┴─────────┴────────┴───────────┴──────────────┘"
       ]
      },
@@ -321,7 +321,6 @@
     }
    ],
    "source": [
-    "\n",
     "df.group_by(\"dummy\").agg(\n",
     "    pl.col(\"y\").num_ext.lstsq(pl.col(\"x1\"), pl.col(\"x2\"), add_bias=False)\n",
     ")\n"
@@ -394,17 +393,17 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>f64</td></tr></thead><tbody><tr><td>-1.051362</td></tr></tbody></table></div>"
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>f64</td></tr></thead><tbody><tr><td>0.048948</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 1)\n",
-       "┌───────────┐\n",
-       "│ a         │\n",
-       "│ ---       │\n",
-       "│ f64       │\n",
-       "╞═══════════╡\n",
-       "│ -1.051362 │\n",
-       "└───────────┘"
+       "┌──────────┐\n",
+       "│ a        │\n",
+       "│ ---      │\n",
+       "│ f64      │\n",
+       "╞══════════╡\n",
+       "│ 0.048948 │\n",
+       "└──────────┘"
       ]
      },
      "execution_count": 11,
@@ -423,39 +422,11 @@
    "execution_count": 12,
    "id": "bf70afa1-28f9-4227-a58f-aa49ed722e4a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr > th,\n",
-       ".dataframe > tbody > tr > td {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>a</th></tr><tr><td>list[f64]</td></tr></thead><tbody><tr><td>[-1.051362, 199997.888517]</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (1, 1)\n",
-       "┌────────────────────────────┐\n",
-       "│ a                          │\n",
-       "│ ---                        │\n",
-       "│ list[f64]                  │\n",
-       "╞════════════════════════════╡\n",
-       "│ [-1.051362, 199997.888517] │\n",
-       "└────────────────────────────┘"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "df.select(\n",
-    "    pl.col(\"a\").num_ext.welch_t(pl.col(\"b\"), return_df = True)\n",
-    ")"
+    "# df.select(\n",
+    "#     pl.col(\"a\").num_ext.welch_t(pl.col(\"b\"), return_df = True)\n",
+    "# )"
    ]
   },
   {
@@ -474,7 +445,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy</th><th>t</th></tr><tr><td>str</td><td>f64</td></tr></thead><tbody><tr><td>&quot;b&quot;</td><td>-146.913633</td></tr><tr><td>&quot;a&quot;</td><td>-146.590267</td></tr></tbody></table></div>"
+       "<small>shape: (2, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy</th><th>t</th></tr><tr><td>str</td><td>f64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>-146.456324</td></tr><tr><td>&quot;b&quot;</td><td>-146.646377</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2, 2)\n",
@@ -483,8 +454,8 @@
        "│ ---   ┆ ---         │\n",
        "│ str   ┆ f64         │\n",
        "╞═══════╪═════════════╡\n",
-       "│ b     ┆ -146.913633 │\n",
-       "│ a     ┆ -146.590267 │\n",
+       "│ a     ┆ -146.456324 │\n",
+       "│ b     ┆ -146.646377 │\n",
        "└───────┴─────────────┘"
       ]
      },
@@ -515,18 +486,19 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy_groups</th><th>l2</th><th>log loss</th><th>roc_auc</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>0.329846</td><td>0.98835</td><td>0.506765</td></tr><tr><td>&quot;b&quot;</td><td>0.333061</td><td>0.998663</td><td>0.500226</td></tr></tbody></table></div>"
+       "<small>shape: (2, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>dummy_groups</th><th>l2</th><th>log loss</th><th>precision</th><th>recall</th><th>f</th><th>average_precision</th><th>roc_auc</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;b&quot;</td><td>0.333623</td><td>1.001309</td><td>0.4999</td><td>0.502372</td><td>0.250566</td><td>0.498001</td><td>0.499788</td></tr><tr><td>&quot;a&quot;</td><td>0.332462</td><td>0.995449</td><td>0.500877</td><td>0.501856</td><td>0.250683</td><td>0.502352</td><td>0.500708</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (2, 4)\n",
-       "┌──────────────┬──────────┬──────────┬──────────┐\n",
-       "│ dummy_groups ┆ l2       ┆ log loss ┆ roc_auc  │\n",
-       "│ ---          ┆ ---      ┆ ---      ┆ ---      │\n",
-       "│ str          ┆ f64      ┆ f64      ┆ f64      │\n",
-       "╞══════════════╪══════════╪══════════╪══════════╡\n",
-       "│ a            ┆ 0.329846 ┆ 0.98835  ┆ 0.506765 │\n",
-       "│ b            ┆ 0.333061 ┆ 0.998663 ┆ 0.500226 │\n",
-       "└──────────────┴──────────┴──────────┴──────────┘"
+       "shape: (2, 8)\n",
+       "┌──────────────┬──────────┬──────────┬───────────┬──────────┬──────────┬────────────────┬──────────┐\n",
+       "│ dummy_groups ┆ l2       ┆ log loss ┆ precision ┆ recall   ┆ f        ┆ average_precis ┆ roc_auc  │\n",
+       "│ ---          ┆ ---      ┆ ---      ┆ ---       ┆ ---      ┆ ---      ┆ ion            ┆ ---      │\n",
+       "│ str          ┆ f64      ┆ f64      ┆ f64       ┆ f64      ┆ f64      ┆ ---            ┆ f64      │\n",
+       "│              ┆          ┆          ┆           ┆          ┆          ┆ f64            ┆          │\n",
+       "╞══════════════╪══════════╪══════════╪═══════════╪══════════╪══════════╪════════════════╪══════════╡\n",
+       "│ b            ┆ 0.333623 ┆ 1.001309 ┆ 0.4999    ┆ 0.502372 ┆ 0.250566 ┆ 0.498001       ┆ 0.499788 │\n",
+       "│ a            ┆ 0.332462 ┆ 0.995449 ┆ 0.500877  ┆ 0.501856 ┆ 0.250683 ┆ 0.502352       ┆ 0.500708 │\n",
+       "└──────────────┴──────────┴──────────┴───────────┴──────────┴──────────┴────────────────┴──────────┘"
       ]
      },
      "execution_count": 14,
@@ -538,8 +510,8 @@
     "df.group_by(\"dummy_groups\").agg(\n",
     "    pl.col(\"actual\").num_ext.l2_loss(pl.col(\"predicted\")).alias(\"l2\"),\n",
     "    pl.col(\"actual\").num_ext.bce(pl.col(\"predicted\")).alias(\"log loss\"),\n",
-    "    pl.col(\"actual\").num_ext.roc_auc(pl.col(\"predicted\")).alias(\"roc_auc\")\n",
-    ")\n"
+    "    pl.col(\"actual\").num_ext.binary_metrics_combo(pl.col(\"predicted\")).alias(\"combo\")\n",
+    ").unnest(\"combo\")\n"
    ]
   },
   {
@@ -590,11 +562,11 @@
    ],
    "source": [
     "size = 100_000\n",
-    "df = pl.DataFrame({\n",
+    "df2 = pl.DataFrame({\n",
     "    \"sen\":[\"Hello, world! I'm going to church.\"] * size,\n",
     "    \"word\":[\"words\", \"word\"] * (size //2)\n",
     "})\n",
-    "df.head()"
+    "df2.head()"
    ]
   },
   {
@@ -613,7 +585,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;going&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;to&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;to&quot;</td></tr><tr><td>&quot;going&quot;</td></tr><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;church&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 1)\n",
@@ -622,11 +594,11 @@
        "│ ---    │\n",
        "│ str    │\n",
        "╞════════╡\n",
-       "│ going  │\n",
        "│ hello  │\n",
+       "│ to     │\n",
+       "│ going  │\n",
        "│ world  │\n",
        "│ church │\n",
-       "│ to     │\n",
        "└────────┘"
       ]
      },
@@ -637,7 +609,7 @@
    ],
    "source": [
     "# Tokenize\n",
-    "df.select(\n",
+    "df2.select(\n",
     "    pl.col(\"sen\").str.to_lowercase().str_ext.tokenize().explode().unique()\n",
     ")"
    ]
@@ -658,7 +630,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;world&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;go&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;hello&quot;</td></tr><tr><td>&quot;go&quot;</td></tr><tr><td>&quot;church&quot;</td></tr><tr><td>&quot;world&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 1)\n",
@@ -667,10 +639,10 @@
        "│ ---    │\n",
        "│ str    │\n",
        "╞════════╡\n",
-       "│ world  │\n",
-       "│ church │\n",
        "│ hello  │\n",
        "│ go     │\n",
+       "│ church │\n",
+       "│ world  │\n",
        "└────────┘"
       ]
      },
@@ -680,7 +652,7 @@
     }
    ],
    "source": [
-    "df.select(\n",
+    "df2.select(\n",
     "    pl.col(\"sen\").str.to_lowercase().str_ext.tokenize(stem=True).explode().unique()\n",
     ")"
    ]
@@ -701,10 +673,10 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (100_000, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>word</th></tr><tr><td>u32</td></tr></thead><tbody><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>&hellip;</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr></tbody></table></div>"
+       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>word</th></tr><tr><td>u32</td></tr></thead><tbody><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (100_000, 1)\n",
+       "shape: (5, 1)\n",
        "┌──────┐\n",
        "│ word │\n",
        "│ ---  │\n",
@@ -714,11 +686,7 @@
        "│ 1    │\n",
        "│ 2    │\n",
        "│ 1    │\n",
-       "│ …    │\n",
        "│ 2    │\n",
-       "│ 1    │\n",
-       "│ 2    │\n",
-       "│ 1    │\n",
        "└──────┘"
       ]
      },
@@ -728,14 +696,101 @@
     }
    ],
    "source": [
-    "df.select(\n",
-    "    pl.col(\"word\").str_ext.levenshtein_dist(\"world\")\n",
-    ")"
+    "df2.select(\n",
+    "    pl.col(\"word\").str_ext.levenshtein(\"world\")\n",
+    ").head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr > th,\n",
+       ".dataframe > tbody > tr > td {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>word</th></tr><tr><td>u32</td></tr></thead><tbody><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>1</td></tr><tr><td>2</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (5, 1)\n",
+       "┌──────┐\n",
+       "│ word │\n",
+       "│ ---  │\n",
+       "│ u32  │\n",
+       "╞══════╡\n",
+       "│ 2    │\n",
+       "│ 1    │\n",
+       "│ 2    │\n",
+       "│ 1    │\n",
+       "│ 2    │\n",
+       "└──────┘"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Damerau-Levenshtein\n",
+    "df2.select(\n",
+    "    pl.col(\"word\").str_ext.d_levenshtein(\"world\")\n",
+    ").head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr > th,\n",
+       ".dataframe > tbody > tr > td {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>word</th></tr><tr><td>f64</td></tr></thead><tbody><tr><td>0.6</td></tr><tr><td>0.8</td></tr><tr><td>0.6</td></tr><tr><td>0.8</td></tr><tr><td>0.6</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (5, 1)\n",
+       "┌──────┐\n",
+       "│ word │\n",
+       "│ ---  │\n",
+       "│ f64  │\n",
+       "╞══════╡\n",
+       "│ 0.6  │\n",
+       "│ 0.8  │\n",
+       "│ 0.6  │\n",
+       "│ 0.8  │\n",
+       "│ 0.6  │\n",
+       "└──────┘"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df2.select(\n",
+    "    pl.col(\"word\").str_ext.levenshtein(\"world\", return_sim = True)\n",
+    ").head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "id": "2dad7633-67fa-47f3-b86a-9f4cd097a650",
    "metadata": {},
    "outputs": [
@@ -749,10 +804,10 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (50_000, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th><th>word</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>sen</th><th>word</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr><tr><td>&quot;Hello, world! …</td><td>&quot;word&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (50_000, 2)\n",
+       "shape: (5, 2)\n",
        "┌───────────────────────────────────┬──────┐\n",
        "│ sen                               ┆ word │\n",
        "│ ---                               ┆ ---  │\n",
@@ -762,23 +817,19 @@
        "│ Hello, world! I'm going to churc… ┆ word │\n",
        "│ Hello, world! I'm going to churc… ┆ word │\n",
        "│ Hello, world! I'm going to churc… ┆ word │\n",
-       "│ …                                 ┆ …    │\n",
-       "│ Hello, world! I'm going to churc… ┆ word │\n",
-       "│ Hello, world! I'm going to churc… ┆ word │\n",
-       "│ Hello, world! I'm going to churc… ┆ word │\n",
        "│ Hello, world! I'm going to churc… ┆ word │\n",
        "└───────────────────────────────────┴──────┘"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.filter(\n",
-    "    pl.col(\"word\").str_ext.levenshtein_dist(\"world\") == 1\n",
-    ")"
+    "df2.filter(\n",
+    "    pl.col(\"word\").str_ext.levenshtein(\"world\") == 1\n",
+    ").head()"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
     {name = "Nelson Griffiths", email = "nelsongriffiths123@gmail.com"}
 ]
 dependencies = [
-    "polars == 0.19.13",
+    "polars == 0.19.14",
 ] 
 
 keywords = ["polars-extension", "scientific-computing", "data-science"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "License :: OSI Approved :: MIT License",
 ]
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     {name = "Tianren Qin", email = "tq9695@gmail.com"},
     {name = "Nelson Griffiths", email = "nelsongriffiths123@gmail.com"}
 ]
 dependencies = [
-    "polars >= 0.19.13",
+    "polars == 0.19.13",
 ] 
 
 keywords = ["polars-extension", "scientific-computing", "data-science"]

--- a/python/polars_ds/__init__.py
+++ b/python/polars_ds/__init__.py
@@ -1,8 +1,5 @@
-version = "0.1.1"
+version = "0.1.2"
 
 from polars_ds.extensions import NumExt, StrExt  # noqa: E402
 
-__all__ = [
-    "NumExt",
-    "StrExt"
-]
+__all__ = ["NumExt", "StrExt"]

--- a/python/polars_ds/extensions.py
+++ b/python/polars_ds/extensions.py
@@ -120,8 +120,7 @@ class NumExt:
 
         (1) Turning sparse multiclass target into dense target.
         (2) Finding the max probability class of a multiclass classification output
-
-        This is just a shortcut for expr.list.eval(pl.element().arg_max())
+        (3) Just a shortcut for expr.list.eval(pl.element().arg_max())
         """
         return self._expr.list.eval(pl.element().arg_max())
 
@@ -320,7 +319,7 @@ class NumExt:
 
     def logloss(self, pred: pl.Expr, normalize: bool = True) -> pl.Expr:
         """
-        Computes Binary Cross Entropy loss.
+        Computes log loss, aka binary cross entropy loss.
 
         Parameters
         ----------
@@ -342,7 +341,7 @@ class NumExt:
 
     def roc_auc(self, pred: pl.Expr) -> pl.Expr:
         """
-        Computes ROC AUC using self (actual) and the predictions.
+        Computes ROC AUC using self as actual and pred as predictions.
 
         Self must be binary and castable to type UInt32. If self is not all 0s and 1s or not binary,
         the result will not make sense, or some error may occur.
@@ -363,7 +362,7 @@ class NumExt:
 
     def binary_metrics_combo(self, pred: pl.Expr, threshold: float = 0.5) -> pl.Expr:
         """
-        Computes the following binary classificaition metrics using self (actual) and the predictions:
+        Computes the following binary classificaition metrics using self as actual and pred as predictions:
         precision, recall, f, average_precision and roc_auc. The return will be a struct with values
         having the names as given here.
 
@@ -371,7 +370,7 @@ class NumExt:
         the result will not make sense, or some error may occur.
 
         Average precision is computed using Sum (R_n - R_n-1)*P_n-1, which is not the textbook definition,
-        but is consistent with how Scikit-learn computes average precision. For more information, see
+        but is consistent with Scikit-learn. For more information, see
         https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html
 
         Parameters
@@ -728,6 +727,12 @@ class StrExt:
 
         return expr
 
+    def line_count(self) -> pl.Expr:
+        """
+        Return the line count of the string column.
+        """
+        return self._expr.str.count_matches(pattern="\n")
+
     def infer_infreq(
         self,
         *,
@@ -971,11 +976,11 @@ class StrExt:
         )
 
 
-class LintExtExpr(pl.Expr):
-    @property
-    def num_ext(self) -> NumExt:
-        return NumExt(self)
+# class LintExtExpr(pl.Expr):
+#     @property
+#     def num_ext(self) -> NumExt:
+#         return NumExt(self)
 
-    @property
-    def str_ext(self) -> StrExt:
-        return StrExt(self)
+#     @property
+#     def str_ext(self) -> StrExt:
+#         return StrExt(self)

--- a/python/polars_ds/type_alias.py
+++ b/python/polars_ds/type_alias.py
@@ -1,0 +1,9 @@
+from typing import Literal
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:  # 3.9
+    from typing_extensions import TypeAlias
+
+AhoCorasickMatchKind: TypeAlias = Literal["standard", "left_most_first", "left_most_longest"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-12"
+channel = "nightly-2023-11-15"

--- a/src/num_ext/tp_fp.rs
+++ b/src/num_ext/tp_fp.rs
@@ -33,9 +33,9 @@ fn tp_fp_frame(predicted: Series, actual: Series, as_ratio: bool) -> PolarsResul
         ])
         .sort("threshold", Default::default())
         .with_columns([
-            (lit(n) - col("cnt").cumsum(false) + col("cnt")).alias("predicted_positive"),
-            (lit(positive_counts) - col("pos_cnt_at_threshold").cumsum(false))
-                .shift_and_fill(1, lit(positive_counts))
+            (lit(n) - col("cnt").cum_sum(false) + col("cnt")).alias("predicted_positive"),
+            (lit(positive_counts) - col("pos_cnt_at_threshold").cum_sum(false))
+                .shift_and_fill(1, positive_counts)
                 .alias("tp"),
         ])
         .select([

--- a/src/num_ext/trapz.rs
+++ b/src/num_ext/trapz.rs
@@ -26,6 +26,11 @@ fn pl_trapz(inputs: &[Series]) -> PolarsResult<Series> {
     let y = inputs[0].f64()?.rechunk();
     let y = y.to_ndarray()?;
     let x = inputs[1].f64()?;
+    if x.null_count() > 0 {
+        return Err(PolarsError::ComputeError(
+            "For trapezoidal integration to work, x axis must not contain nulls.".into(),
+        ))
+    }
     if x.len() == 1 {
         let dx = x.get(0).unwrap();
         Ok(Series::from_iter([trapz_dx(y, dx)]))

--- a/src/num_ext/trapz.rs
+++ b/src/num_ext/trapz.rs
@@ -29,7 +29,7 @@ fn pl_trapz(inputs: &[Series]) -> PolarsResult<Series> {
     if x.null_count() > 0 {
         return Err(PolarsError::ComputeError(
             "For trapezoidal integration to work, x axis must not contain nulls.".into(),
-        ))
+        ));
     }
     if x.len() == 1 {
         let dx = x.get(0).unwrap();

--- a/src/str_ext/aho_corasick.rs
+++ b/src/str_ext/aho_corasick.rs
@@ -1,6 +1,6 @@
+use aho_corasick::{AhoCorasick, MatchKind};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use aho_corasick::{AhoCorasick, MatchKind};
 
 fn list_u16_output(_: &[Field]) -> PolarsResult<Field> {
     Ok(Field::new(
@@ -20,19 +20,20 @@ fn str_to_matchkind(value: &str) -> MatchKind {
     match value {
         "left_most_longest" => MatchKind::LeftmostLongest,
         "left_most_first" => MatchKind::LeftmostFirst,
-        _ => MatchKind::Standard
-    }   
+        _ => MatchKind::Standard,
+    }
 }
 
 #[polars_expr(output_type_func=list_u16_output)]
 fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
-
     let str_col = inputs[0].utf8()?;
     let patterns = inputs[1].utf8()?;
-    let patterns:Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
+    let patterns: Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
     let n_pat = patterns.len();
     if n_pat > u16::MAX as usize {
-        return Err(PolarsError::ComputeError("Too many patterns to match.".into()))
+        return Err(PolarsError::ComputeError(
+            "Too many patterns to match.".into(),
+        ));
     }
 
     let case_insensitive = inputs[2].bool()?;
@@ -40,7 +41,7 @@ fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
 
     let mk = inputs[3].utf8()?;
     let mk = mk.get(0).unwrap();
-    let mk:MatchKind = str_to_matchkind(mk);
+    let mk: MatchKind = str_to_matchkind(mk);
 
     let ac_builder = AhoCorasick::builder()
         .ascii_case_insensitive(case_insensitive)
@@ -48,22 +49,26 @@ fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
         .build(patterns);
 
     match ac_builder {
-
         Ok(ac) => {
-
             // Is there a way to make this work?
             // let out:ChunkedArray<FixedSizeListType> = str_col.apply_values_generic(op);
 
             let mut builder = ListPrimitiveChunkedBuilder::<UInt16Type>::new(
-                "match", str_col.len(), n_pat, DataType::UInt16
+                "match",
+                str_col.len(),
+                n_pat,
+                DataType::UInt16,
             );
-            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty. 
+            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty.
             // Right now this is not the best choice.
             // One thing we can do is to enforce the length to be < values_capacity.
-            
+
             for op_s in str_col.into_iter() {
                 if let Some(s) = op_s {
-                    let matches = ac.find_iter(s).map(|m| m.pattern().as_u32() as u16).collect::<Vec<u16>>();
+                    let matches = ac
+                        .find_iter(s)
+                        .map(|m| m.pattern().as_u32() as u16)
+                        .collect::<Vec<u16>>();
                     if matches.is_empty() {
                         builder.append_null();
                     } else {
@@ -76,19 +81,20 @@ fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
             let out = builder.finish();
             Ok(out.into_series())
         }
-        , Err(e) => Err(PolarsError::ComputeError(e.to_string().into()))
+        Err(e) => Err(PolarsError::ComputeError(e.to_string().into())),
     }
 }
 
 #[polars_expr(output_type_func=list_str_output)]
 fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
-
     let str_col = inputs[0].utf8()?;
     let patterns = inputs[1].utf8()?;
-    let patterns:Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
+    let patterns: Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
     let n_pat = patterns.len();
     if n_pat > u16::MAX as usize {
-        return Err(PolarsError::ComputeError("Too many patterns to match.".into()))
+        return Err(PolarsError::ComputeError(
+            "Too many patterns to match.".into(),
+        ));
     }
 
     let case_insensitive = inputs[2].bool()?;
@@ -96,7 +102,7 @@ fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
 
     let mk = inputs[3].utf8()?;
     let mk = mk.get(0).unwrap();
-    let mk:MatchKind = str_to_matchkind(mk);
+    let mk: MatchKind = str_to_matchkind(mk);
 
     let ac_builder = AhoCorasick::builder()
         .ascii_case_insensitive(case_insensitive)
@@ -104,30 +110,24 @@ fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
         .build(&patterns);
 
     match ac_builder {
-
         Ok(ac) => {
-
             // Is there a way to make this work?
             // let out:ChunkedArray<FixedSizeListType> = str_col.apply_values_generic(op);
 
-            let mut builder = ListUtf8ChunkedBuilder::new(
-                "match", str_col.len(), n_pat
-            ); 
-            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty. 
+            let mut builder = ListUtf8ChunkedBuilder::new("match", str_col.len(), n_pat);
+            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty.
             // Right now this is not the best choice.
-            
+
             for op_s in str_col.into_iter() {
                 if let Some(s) = op_s {
-
-                    let matches = ac.find_iter(s)
-                        .map(|m| 
-                            patterns[m.pattern().as_usize()]
-                        )
+                    let matches = ac
+                        .find_iter(s)
+                        .map(|m| patterns[m.pattern().as_usize()])
                         .collect::<Utf8Chunked>();
                     if matches.is_empty() {
                         builder.append_null();
                     } else {
-                        let s:Series = matches.into();
+                        let s: Series = matches.into();
                         let _ = builder.append_series(&s)?;
                     }
                 } else {
@@ -137,6 +137,6 @@ fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
             let out = builder.finish();
             Ok(out.into_series())
         }
-        , Err(e) => Err(PolarsError::ComputeError(e.to_string().into()))
+        Err(e) => Err(PolarsError::ComputeError(e.to_string().into())),
     }
 }

--- a/src/str_ext/aho_corasick.rs
+++ b/src/str_ext/aho_corasick.rs
@@ -61,7 +61,7 @@ fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
             );
             // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty.
             // Right now this is not the best choice.
-            // One thing we can do is to enforce the length to be < values_capacity.
+            // One thing we can do is to enforce the length to be <= values_capacity.
 
             for op_s in str_col.into_iter() {
                 if let Some(s) = op_s {
@@ -114,7 +114,7 @@ fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
             // Is there a way to make this work?
             // let out:ChunkedArray<FixedSizeListType> = str_col.apply_values_generic(op);
 
-            let mut builder = ListUtf8ChunkedBuilder::new("match", str_col.len(), n_pat);
+            let mut builder = ListUtf8ChunkedBuilder::new("match", str_col.len(), 20);
             // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty.
             // Right now this is not the best choice.
 

--- a/src/str_ext/aho_corasick.rs
+++ b/src/str_ext/aho_corasick.rs
@@ -1,0 +1,142 @@
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use aho_corasick::{AhoCorasick, MatchKind};
+
+fn list_u16_output(_: &[Field]) -> PolarsResult<Field> {
+    Ok(Field::new(
+        "list_u16",
+        DataType::List(Box::new(DataType::UInt16)),
+    ))
+}
+
+fn list_str_output(_: &[Field]) -> PolarsResult<Field> {
+    Ok(Field::new(
+        "list_str",
+        DataType::List(Box::new(DataType::Utf8)),
+    ))
+}
+
+fn str_to_matchkind(value: &str) -> MatchKind {
+    match value {
+        "left_most_longest" => MatchKind::LeftmostLongest,
+        "left_most_first" => MatchKind::LeftmostFirst,
+        _ => MatchKind::Standard
+    }   
+}
+
+#[polars_expr(output_type_func=list_u16_output)]
+fn pl_ac_match(inputs: &[Series]) -> PolarsResult<Series> {
+
+    let str_col = inputs[0].utf8()?;
+    let patterns = inputs[1].utf8()?;
+    let patterns:Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
+    let n_pat = patterns.len();
+    if n_pat > u16::MAX as usize {
+        return Err(PolarsError::ComputeError("Too many patterns to match.".into()))
+    }
+
+    let case_insensitive = inputs[2].bool()?;
+    let case_insensitive = case_insensitive.get(0).unwrap();
+
+    let mk = inputs[3].utf8()?;
+    let mk = mk.get(0).unwrap();
+    let mk:MatchKind = str_to_matchkind(mk);
+
+    let ac_builder = AhoCorasick::builder()
+        .ascii_case_insensitive(case_insensitive)
+        .match_kind(mk)
+        .build(patterns);
+
+    match ac_builder {
+
+        Ok(ac) => {
+
+            // Is there a way to make this work?
+            // let out:ChunkedArray<FixedSizeListType> = str_col.apply_values_generic(op);
+
+            let mut builder = ListPrimitiveChunkedBuilder::<UInt16Type>::new(
+                "match", str_col.len(), n_pat, DataType::UInt16
+            );
+            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty. 
+            // Right now this is not the best choice.
+            // One thing we can do is to enforce the length to be < values_capacity.
+            
+            for op_s in str_col.into_iter() {
+                if let Some(s) = op_s {
+                    let matches = ac.find_iter(s).map(|m| m.pattern().as_u32() as u16).collect::<Vec<u16>>();
+                    if matches.is_empty() {
+                        builder.append_null();
+                    } else {
+                        builder.append_slice(&matches);
+                    }
+                } else {
+                    builder.append_null();
+                }
+            }
+            let out = builder.finish();
+            Ok(out.into_series())
+        }
+        , Err(e) => Err(PolarsError::ComputeError(e.to_string().into()))
+    }
+}
+
+#[polars_expr(output_type_func=list_str_output)]
+fn pl_ac_match_str(inputs: &[Series]) -> PolarsResult<Series> {
+
+    let str_col = inputs[0].utf8()?;
+    let patterns = inputs[1].utf8()?;
+    let patterns:Vec<&str> = patterns.into_iter().filter_map(|s| s).collect();
+    let n_pat = patterns.len();
+    if n_pat > u16::MAX as usize {
+        return Err(PolarsError::ComputeError("Too many patterns to match.".into()))
+    }
+
+    let case_insensitive = inputs[2].bool()?;
+    let case_insensitive = case_insensitive.get(0).unwrap();
+
+    let mk = inputs[3].utf8()?;
+    let mk = mk.get(0).unwrap();
+    let mk:MatchKind = str_to_matchkind(mk);
+
+    let ac_builder = AhoCorasick::builder()
+        .ascii_case_insensitive(case_insensitive)
+        .match_kind(mk)
+        .build(&patterns);
+
+    match ac_builder {
+
+        Ok(ac) => {
+
+            // Is there a way to make this work?
+            // let out:ChunkedArray<FixedSizeListType> = str_col.apply_values_generic(op);
+
+            let mut builder = ListUtf8ChunkedBuilder::new(
+                "match", str_col.len(), n_pat
+            ); 
+            // n_pat is just capacity to initialize. We can go beyond n_pat, with a performance penalty. 
+            // Right now this is not the best choice.
+            
+            for op_s in str_col.into_iter() {
+                if let Some(s) = op_s {
+
+                    let matches = ac.find_iter(s)
+                        .map(|m| 
+                            patterns[m.pattern().as_usize()]
+                        )
+                        .collect::<Utf8Chunked>();
+                    if matches.is_empty() {
+                        builder.append_null();
+                    } else {
+                        let s:Series = matches.into();
+                        let _ = builder.append_series(&s)?;
+                    }
+                } else {
+                    builder.append_null();
+                }
+            }
+            let out = builder.finish();
+            Ok(out.into_series())
+        }
+        , Err(e) => Err(PolarsError::ComputeError(e.to_string().into()))
+    }
+}

--- a/src/str_ext/hamming.rs
+++ b/src/str_ext/hamming.rs
@@ -22,7 +22,7 @@ fn optional_hamming(op_w1: Option<&str>, op_w2: Option<&str>) -> Option<u32> {
 }
 
 #[polars_expr(output_type=UInt32)]
-fn pl_hamming_dist(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_hamming(inputs: &[Series]) -> PolarsResult<Series> {
     let ca1 = inputs[0].utf8()?;
     let ca2 = inputs[1].utf8()?;
     let parallel = inputs[2].bool()?;

--- a/src/str_ext/hamming_dist.rs
+++ b/src/str_ext/hamming_dist.rs
@@ -3,17 +3,14 @@ use pyo3_polars::{
     derive::polars_expr,
     export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
 };
+use strsim::hamming;
 
 #[inline]
-pub fn hamming_dist(s1: &str, s2: &str) -> Option<u32> {
-    if s1.len() != s2.len() {
-        return None;
+fn hamming_dist(a: &str, b: &str) -> Option<u32> {
+    match hamming(a, b) {
+        Ok(d) => Some(d as u32),
+        _ => None,
     }
-    Some(
-        s1.chars()
-            .zip(s2.chars())
-            .fold(0, |a, (b, c)| a + (b != c) as u32),
-    )
 }
 
 fn optional_hamming(op_w1: Option<&str>, op_w2: Option<&str>) -> Option<u32> {
@@ -43,7 +40,7 @@ fn pl_hamming_dist(inputs: &[Series]) -> PolarsResult<Series> {
         let out: UInt32Chunked = if parallel {
             ca1.par_iter().map(|op_s| op(op_s)).collect()
         } else {
-            ca1.apply_generic(op)
+            ca1.apply_generic(|x| op(x))
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {

--- a/src/str_ext/jaro.rs
+++ b/src/str_ext/jaro.rs
@@ -1,0 +1,56 @@
+use polars::prelude::{arity::binary_elementwise_values, *};
+use pyo3_polars::{
+    derive::polars_expr,
+    export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
+};
+// Jaro winkler seems to have a bug related to prefix length
+use strsim::jaro;
+
+#[inline]
+fn optional_jaro(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<f64> {
+    if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+        Some(jaro(s1, s2))
+    } else {
+        None
+    }
+}
+
+// #[inline]
+// fn optional_jaro_winkler(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<f64> {
+//     if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+//         Some(jaro_winkler(s1, s2))
+//     } else {
+//         None
+//     }
+// }
+
+#[polars_expr(output_type=UInt32)]
+fn pl_jaro(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca1 = inputs[0].utf8()?;
+    let ca2 = inputs[1].utf8()?;
+    let parallel = inputs[2].bool()?;
+    let parallel = parallel.get(0).unwrap();
+    if ca2.len() == 1 {
+        let r = ca2.get(0);
+        let out: Float64Chunked = if parallel {
+            ca1.par_iter().map(|op_s| optional_jaro(op_s, r)).collect()
+        } else {
+            ca1.apply_nonnull_values_generic(DataType::Float64, |x| jaro(x, r.unwrap()))
+        };
+        Ok(out.into_series())
+    } else if ca1.len() == ca2.len() {
+        let out: Float64Chunked = if parallel {
+            ca1.par_iter_indexed()
+                .zip(ca2.par_iter_indexed())
+                .map(|(op_w1, op_w2)| optional_jaro(op_w1, op_w2))
+                .collect()
+        } else {
+            binary_elementwise_values(ca1, ca2, |x, y| jaro(x, y))
+        };
+        Ok(out.into_series())
+    } else {
+        Err(PolarsError::ShapeMismatch(
+            "Inputs must have the same length.".into(),
+        ))
+    }
+}

--- a/src/str_ext/levenshtein.rs
+++ b/src/str_ext/levenshtein.rs
@@ -50,18 +50,15 @@ fn pl_levenshtein(inputs: &[Series]) -> PolarsResult<Series> {
     let parallel = inputs[2].bool()?;
     let parallel = parallel.get(0).unwrap();
     if ca2.len() == 1 {
-        let r = ca2.get(0).unwrap();
+        let r = ca2.get(0);
         let out: UInt32Chunked = if parallel {
-            let op = |op_s| {
-                if let Some(s) = op_s {
-                    Some(levenshtein(s, r) as u32)
-                } else {
-                    None
-                }
-            };
-            ca1.par_iter().map(|op_s| op(op_s)).collect()
+            ca1.par_iter()
+                .map(|op_s| optional_levenshtein(op_s, r))
+                .collect()
         } else {
-            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| levenshtein(x, r) as u32)
+            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| {
+                levenshtein(x, r.unwrap()) as u32
+            })
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
@@ -88,18 +85,15 @@ fn pl_levenshtein_sim(inputs: &[Series]) -> PolarsResult<Series> {
     let parallel = inputs[2].bool()?;
     let parallel = parallel.get(0).unwrap();
     if ca2.len() == 1 {
-        let r = ca2.get(0).unwrap();
+        let r = ca2.get(0);
         let out: Float64Chunked = if parallel {
-            let op = |op_s| {
-                if let Some(s) = op_s {
-                    Some(normalized_levenshtein(s, r))
-                } else {
-                    None
-                }
-            };
-            ca1.par_iter().map(|op_s| op(op_s)).collect()
+            ca1.par_iter()
+                .map(|op_s| optional_levenshtein_sim(op_s, r))
+                .collect()
         } else {
-            ca1.apply_nonnull_values_generic(DataType::Float64, |x| normalized_levenshtein(x, r))
+            ca1.apply_nonnull_values_generic(DataType::Float64, |x| {
+                normalized_levenshtein(x, r.unwrap())
+            })
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
@@ -126,18 +120,15 @@ fn pl_d_levenshtein(inputs: &[Series]) -> PolarsResult<Series> {
     let parallel = inputs[2].bool()?;
     let parallel = parallel.get(0).unwrap();
     if ca2.len() == 1 {
-        let r = ca2.get(0).unwrap();
+        let r = ca2.get(0);
         let out: UInt32Chunked = if parallel {
-            let op = |op_s| {
-                if let Some(s) = op_s {
-                    Some(damerau_levenshtein(s, r) as u32)
-                } else {
-                    None
-                }
-            };
-            ca1.par_iter().map(|op_s| op(op_s)).collect()
+            ca1.par_iter()
+                .map(|op_s| optional_damerau_levenshtein(op_s, r))
+                .collect()
         } else {
-            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| damerau_levenshtein(x, r) as u32)
+            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| {
+                damerau_levenshtein(x, r.unwrap()) as u32
+            })
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
@@ -164,19 +155,14 @@ fn pl_d_levenshtein_sim(inputs: &[Series]) -> PolarsResult<Series> {
     let parallel = inputs[2].bool()?;
     let parallel = parallel.get(0).unwrap();
     if ca2.len() == 1 {
-        let r = ca2.get(0).unwrap();
+        let r = ca2.get(0);
         let out: Float64Chunked = if parallel {
-            let op = |op_s| {
-                if let Some(s) = op_s {
-                    Some(normalized_damerau_levenshtein(s, r))
-                } else {
-                    None
-                }
-            };
-            ca1.par_iter().map(|op_s| op(op_s)).collect()
+            ca1.par_iter()
+                .map(|op_s| optional_damerau_levenshtein_sim(op_s, r))
+                .collect()
         } else {
             ca1.apply_nonnull_values_generic(DataType::Float64, |x| {
-                normalized_damerau_levenshtein(x, r)
+                normalized_damerau_levenshtein(x, r.unwrap())
             })
         };
         Ok(out.into_series())

--- a/src/str_ext/levenshtein_dist.rs
+++ b/src/str_ext/levenshtein_dist.rs
@@ -3,45 +3,48 @@ use pyo3_polars::{
     derive::polars_expr,
     export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
 };
+use strsim::{
+    damerau_levenshtein, levenshtein, normalized_damerau_levenshtein, normalized_levenshtein,
+};
 
-pub fn levenshtein_dist(s1: &str, s2: &str) -> u32 {
-    // https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
-
-    let (len1, len2) = (s1.len(), s2.len());
-    let mut dp: Vec<Vec<u32>> = vec![vec![0; len2 + 1]; len1 + 1];
-
-    // Initialize the first row and first column
-    for i in 0..=len1 {
-        dp[i][0] = i as u32;
+#[inline]
+fn optional_damerau_levenshtein(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<u32> {
+    if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+        Some(damerau_levenshtein(s1, s2) as u32)
+    } else {
+        None
     }
-
-    for j in 0..=len2 {
-        dp[0][j] = j as u32;
-    }
-
-    // Fill the dp matrix using dynamic programming
-    for (i, char1) in s1.chars().enumerate() {
-        for (j, char2) in s2.chars().enumerate() {
-            if char1 == char2 {
-                dp[i + 1][j + 1] = dp[i][j];
-            } else {
-                dp[i + 1][j + 1] = 1 + dp[i][j].min(dp[i][j + 1].min(dp[i + 1][j]));
-            }
-        }
-    }
-    dp[len1][len2]
 }
 
-fn optional_levenshtein(op_w1: Option<&str>, op_w2: Option<&str>) -> Option<u32> {
-    if let (Some(w1), Some(w2)) = (op_w1, op_w2) {
-        Some(levenshtein_dist(w1, w2))
+#[inline]
+fn optional_damerau_levenshtein_sim(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<f64> {
+    if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+        Some(normalized_damerau_levenshtein(s1, s2))
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn optional_levenshtein(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<u32> {
+    if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+        Some(levenshtein(s1, s2) as u32)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn optional_levenshtein_sim(op_s1: Option<&str>, op_s2: Option<&str>) -> Option<f64> {
+    if let (Some(s1), Some(s2)) = (op_s1, op_s2) {
+        Some(normalized_levenshtein(s1, s2))
     } else {
         None
     }
 }
 
 #[polars_expr(output_type=UInt32)]
-fn pl_levenshtein_dist(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_levenshtein(inputs: &[Series]) -> PolarsResult<Series> {
     let ca1 = inputs[0].utf8()?;
     let ca2 = inputs[1].utf8()?;
     let parallel = inputs[2].bool()?;
@@ -51,14 +54,14 @@ fn pl_levenshtein_dist(inputs: &[Series]) -> PolarsResult<Series> {
         let out: UInt32Chunked = if parallel {
             let op = |op_s| {
                 if let Some(s) = op_s {
-                    Some(levenshtein_dist(s, r))
+                    Some(levenshtein(s, r) as u32)
                 } else {
                     None
                 }
             };
             ca1.par_iter().map(|op_s| op(op_s)).collect()
         } else {
-            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| levenshtein_dist(x, r))
+            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| levenshtein(x, r) as u32)
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
@@ -68,7 +71,123 @@ fn pl_levenshtein_dist(inputs: &[Series]) -> PolarsResult<Series> {
                 .map(|(op_w1, op_w2)| optional_levenshtein(op_w1, op_w2))
                 .collect()
         } else {
-            binary_elementwise_values(ca1, ca2, levenshtein_dist)
+            binary_elementwise_values(ca1, ca2, |x, y| levenshtein(x, y) as u32)
+        };
+        Ok(out.into_series())
+    } else {
+        Err(PolarsError::ShapeMismatch(
+            "Inputs must have the same length.".into(),
+        ))
+    }
+}
+
+#[polars_expr(output_type=Float64)]
+fn pl_levenshtein_sim(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca1 = inputs[0].utf8()?;
+    let ca2 = inputs[1].utf8()?;
+    let parallel = inputs[2].bool()?;
+    let parallel = parallel.get(0).unwrap();
+    if ca2.len() == 1 {
+        let r = ca2.get(0).unwrap();
+        let out: Float64Chunked = if parallel {
+            let op = |op_s| {
+                if let Some(s) = op_s {
+                    Some(normalized_levenshtein(s, r))
+                } else {
+                    None
+                }
+            };
+            ca1.par_iter().map(|op_s| op(op_s)).collect()
+        } else {
+            ca1.apply_nonnull_values_generic(DataType::Float64, |x| normalized_levenshtein(x, r))
+        };
+        Ok(out.into_series())
+    } else if ca1.len() == ca2.len() {
+        let out: Float64Chunked = if parallel {
+            ca1.par_iter_indexed()
+                .zip(ca2.par_iter_indexed())
+                .map(|(op_w1, op_w2)| optional_levenshtein_sim(op_w1, op_w2))
+                .collect()
+        } else {
+            binary_elementwise_values(ca1, ca2, |x, y| normalized_levenshtein(x, y))
+        };
+        Ok(out.into_series())
+    } else {
+        Err(PolarsError::ShapeMismatch(
+            "Inputs must have the same length.".into(),
+        ))
+    }
+}
+
+#[polars_expr(output_type=UInt32)]
+fn pl_d_levenshtein(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca1 = inputs[0].utf8()?;
+    let ca2 = inputs[1].utf8()?;
+    let parallel = inputs[2].bool()?;
+    let parallel = parallel.get(0).unwrap();
+    if ca2.len() == 1 {
+        let r = ca2.get(0).unwrap();
+        let out: UInt32Chunked = if parallel {
+            let op = |op_s| {
+                if let Some(s) = op_s {
+                    Some(damerau_levenshtein(s, r) as u32)
+                } else {
+                    None
+                }
+            };
+            ca1.par_iter().map(|op_s| op(op_s)).collect()
+        } else {
+            ca1.apply_nonnull_values_generic(DataType::UInt32, |x| damerau_levenshtein(x, r) as u32)
+        };
+        Ok(out.into_series())
+    } else if ca1.len() == ca2.len() {
+        let out: UInt32Chunked = if parallel {
+            ca1.par_iter_indexed()
+                .zip(ca2.par_iter_indexed())
+                .map(|(op_w1, op_w2)| optional_damerau_levenshtein(op_w1, op_w2))
+                .collect()
+        } else {
+            binary_elementwise_values(ca1, ca2, |x, y| damerau_levenshtein(x, y) as u32)
+        };
+        Ok(out.into_series())
+    } else {
+        Err(PolarsError::ShapeMismatch(
+            "Inputs must have the same length.".into(),
+        ))
+    }
+}
+
+#[polars_expr(output_type=Float64)]
+fn pl_d_levenshtein_sim(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca1 = inputs[0].utf8()?;
+    let ca2 = inputs[1].utf8()?;
+    let parallel = inputs[2].bool()?;
+    let parallel = parallel.get(0).unwrap();
+    if ca2.len() == 1 {
+        let r = ca2.get(0).unwrap();
+        let out: Float64Chunked = if parallel {
+            let op = |op_s| {
+                if let Some(s) = op_s {
+                    Some(normalized_damerau_levenshtein(s, r))
+                } else {
+                    None
+                }
+            };
+            ca1.par_iter().map(|op_s| op(op_s)).collect()
+        } else {
+            ca1.apply_nonnull_values_generic(DataType::Float64, |x| {
+                normalized_damerau_levenshtein(x, r)
+            })
+        };
+        Ok(out.into_series())
+    } else if ca1.len() == ca2.len() {
+        let out: Float64Chunked = if parallel {
+            ca1.par_iter_indexed()
+                .zip(ca2.par_iter_indexed())
+                .map(|(op_w1, op_w2)| optional_damerau_levenshtein_sim(op_w1, op_w2))
+                .collect()
+        } else {
+            binary_elementwise_values(ca1, ca2, |x, y| normalized_damerau_levenshtein(x, y))
         };
         Ok(out.into_series())
     } else {

--- a/src/str_ext/mod.rs
+++ b/src/str_ext/mod.rs
@@ -1,7 +1,7 @@
+mod aho_corasick;
 mod consts;
 mod hamming_dist;
 mod levenshtein_dist;
 mod snowball;
 mod snowball_stem;
 mod str_jaccard;
-mod aho_corasick;

--- a/src/str_ext/mod.rs
+++ b/src/str_ext/mod.rs
@@ -1,13 +1,21 @@
 mod aho_corasick;
 mod consts;
-mod hamming_dist;
-mod levenshtein_dist;
+mod hamming;
+mod jaro;
+mod levenshtein;
 mod overlap;
 mod snowball;
 mod snowball_stem;
 mod sorensen_dice;
 mod str_jaccard;
 
+// Most str dist / similarity metrics are powered by strsim. They have good performance.
+// E.g. Levenshtein has 3x better performance than my own implementation.
+// However, I saw people saying in the github issue section that things can be improved.
+// The strsim project is no longer maintained. If there is a need to improve performance
+// further, we can fork and develop it ourselves (currently just me).
+
+// Hashbrown has better perf than Rust's HashSet
 use hashbrown::HashSet;
 
 #[inline]

--- a/src/str_ext/mod.rs
+++ b/src/str_ext/mod.rs
@@ -9,6 +9,8 @@ mod snowball_stem;
 mod sorensen_dice;
 mod str_jaccard;
 
+// use unicode_segmentation::UnicodeSegmentation;
+
 // Most str dist / similarity metrics are powered by strsim. They have good performance.
 // E.g. Levenshtein has 3x better performance than my own implementation.
 // However, I saw people saying in the github issue section that things can be improved.
@@ -47,4 +49,40 @@ pub fn str_set_sim_helper(w1: &str, w2: &str, n: usize) -> (usize, usize, usize)
 
     let intersection = s1.intersection(&s2).count();
     (s1.len(), s2.len(), intersection)
+}
+
+
+#[inline]
+pub fn remove_common_prefix<'a>(s1:&'a str, s2:&'a str) -> (&'a str, &'a str) {
+
+    let iter1 = s1.chars();
+    let iter2 = s2.chars();
+    let mut prefix:String = String::new();
+    for (c1, c2) in iter1.zip(iter2) {
+        if c1 == c2 {
+            prefix.push(c1);
+        } else {
+            break
+        }
+    }
+    (s1.strip_prefix(&prefix).unwrap(), s2.strip_prefix(&prefix).unwrap())
+
+}
+
+#[inline]
+pub fn remove_common_suffix<'a>(s1:&'a str, s2:&'a str) -> (&'a str, &'a str) {
+
+
+    let iter1 = s1.chars().rev();
+    let iter2 = s2.chars().rev();
+    let mut suffix:String = String::new();
+    for (c1, c2) in iter1.zip(iter2) {
+        if c1 == c2 {
+            suffix.push(c1);
+        } else {
+            break
+        }
+    }
+    suffix = suffix.chars().rev().collect(); // meh... I have to...
+    (s1.strip_suffix(&suffix).unwrap(), s2.strip_suffix(&suffix).unwrap())
 }

--- a/src/str_ext/mod.rs
+++ b/src/str_ext/mod.rs
@@ -4,3 +4,4 @@ mod levenshtein_dist;
 mod snowball;
 mod snowball_stem;
 mod str_jaccard;
+mod aho_corasick;

--- a/src/str_ext/mod.rs
+++ b/src/str_ext/mod.rs
@@ -2,6 +2,41 @@ mod aho_corasick;
 mod consts;
 mod hamming_dist;
 mod levenshtein_dist;
+mod overlap;
 mod snowball;
 mod snowball_stem;
+mod sorensen_dice;
 mod str_jaccard;
+
+use hashbrown::HashSet;
+
+#[inline]
+pub fn str_set_sim_helper(w1: &str, w2: &str, n: usize) -> (usize, usize, usize) {
+    // output: set 1 size, set 2 size, intersection size
+
+    let w1_len = w1.len();
+    let w2_len = w2.len();
+
+    // as long as intersection size is 0, output will be correct
+    if (w1_len == 0) && (w2_len == 0) {
+        return (0, 0, 0);
+    } else if (w1_len == 0) | (w2_len == 0) {
+        return (0, 0, 0);
+    }
+
+    // Both are nonempty
+    let s1: HashSet<&[u8]> = if w1_len < n {
+        HashSet::from_iter([w1.as_bytes()])
+    } else {
+        HashSet::from_iter(w1.as_bytes().windows(n))
+    };
+
+    let s2: HashSet<&[u8]> = if w2_len < n {
+        HashSet::from_iter([w2.as_bytes()])
+    } else {
+        HashSet::from_iter(w2.as_bytes().windows(n))
+    };
+
+    let intersection = s1.intersection(&s2).count();
+    (s1.len(), s2.len(), intersection)
+}

--- a/src/str_ext/overlap.rs
+++ b/src/str_ext/overlap.rs
@@ -5,21 +5,21 @@ use pyo3_polars::{
     export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
 };
 
-fn str_jaccard(w1: &str, w2: &str, n: usize) -> f64 {
+fn overlap_coeff(w1: &str, w2: &str, n: usize) -> f64 {
     let (s1, s2, intersect) = str_set_sim_helper(w1, w2, n);
-    (intersect as f64) / ((s1 + s2 - intersect) as f64)
+    (intersect as f64) / ((s1.min(s2)) as f64)
 }
 
-fn optional_str_jaccard(op_w1: Option<&str>, op_w2: Option<&str>, n: usize) -> Option<f64> {
+fn optional_overlap_coeff(op_w1: Option<&str>, op_w2: Option<&str>, n: usize) -> Option<f64> {
     if let (Some(w1), Some(w2)) = (op_w1, op_w2) {
-        Some(str_jaccard(w1, w2, n))
+        Some(overlap_coeff(w1, w2, n))
     } else {
         None
     }
 }
 
 #[polars_expr(output_type=Float64)]
-fn pl_str_jaccard(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_overlap_coeff(inputs: &[Series]) -> PolarsResult<Series> {
     let ca1 = inputs[0].utf8()?;
     let ca2 = inputs[1].utf8()?;
 
@@ -35,20 +35,20 @@ fn pl_str_jaccard(inputs: &[Series]) -> PolarsResult<Series> {
         let r = ca2.get(0); // .unwrap();
         let out: Float64Chunked = if parallel {
             ca1.par_iter()
-                .map(|op_s| optional_str_jaccard(op_s, r, n))
+                .map(|op_s| optional_overlap_coeff(op_s, r, n))
                 .collect()
         } else {
-            ca1.apply_generic(|op_s| optional_str_jaccard(op_s, r, n))
+            ca1.apply_generic(|op_s| optional_overlap_coeff(op_s, r, n))
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
         let out: Float64Chunked = if parallel {
             ca1.par_iter_indexed()
                 .zip(ca2.par_iter_indexed())
-                .map(|(op_w1, op_w2)| optional_str_jaccard(op_w1, op_w2, n))
+                .map(|(op_w1, op_w2)| optional_overlap_coeff(op_w1, op_w2, n))
                 .collect()
         } else {
-            binary_elementwise_values(ca1, ca2, |x, y| str_jaccard(x, y, n))
+            binary_elementwise_values(ca1, ca2, |x, y| overlap_coeff(x, y, n))
         };
         Ok(out.into_series())
     } else {

--- a/src/str_ext/snowball_stem.rs
+++ b/src/str_ext/snowball_stem.rs
@@ -34,7 +34,6 @@ fn pl_snowball_stem(inputs: &[Series]) -> PolarsResult<Series> {
             .map(|op_s| snowball_stem(op_s, no_stop))
             .collect()
     } else {
-        // have to do apply_generic, not apply_values because snowball may return None for string inputs.
         ca.apply_generic(|op_s| snowball_stem(op_s, no_stop))
     };
     Ok(out.into_series())

--- a/src/str_ext/sorensen_dice.rs
+++ b/src/str_ext/sorensen_dice.rs
@@ -5,21 +5,21 @@ use pyo3_polars::{
     export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
 };
 
-fn str_jaccard(w1: &str, w2: &str, n: usize) -> f64 {
+fn sorensen_dice(w1: &str, w2: &str, n: usize) -> f64 {
     let (s1, s2, intersect) = str_set_sim_helper(w1, w2, n);
-    (intersect as f64) / ((s1 + s2 - intersect) as f64)
+    ((2 * intersect) as f64) / ((s1 + s2) as f64)
 }
 
-fn optional_str_jaccard(op_w1: Option<&str>, op_w2: Option<&str>, n: usize) -> Option<f64> {
+fn optional_sorensen_dice(op_w1: Option<&str>, op_w2: Option<&str>, n: usize) -> Option<f64> {
     if let (Some(w1), Some(w2)) = (op_w1, op_w2) {
-        Some(str_jaccard(w1, w2, n))
+        Some(sorensen_dice(w1, w2, n))
     } else {
         None
     }
 }
 
 #[polars_expr(output_type=Float64)]
-fn pl_str_jaccard(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_sorensen_dice(inputs: &[Series]) -> PolarsResult<Series> {
     let ca1 = inputs[0].utf8()?;
     let ca2 = inputs[1].utf8()?;
 
@@ -35,20 +35,20 @@ fn pl_str_jaccard(inputs: &[Series]) -> PolarsResult<Series> {
         let r = ca2.get(0); // .unwrap();
         let out: Float64Chunked = if parallel {
             ca1.par_iter()
-                .map(|op_s| optional_str_jaccard(op_s, r, n))
+                .map(|op_s| optional_sorensen_dice(op_s, r, n))
                 .collect()
         } else {
-            ca1.apply_generic(|op_s| optional_str_jaccard(op_s, r, n))
+            ca1.apply_generic(|op_s| optional_sorensen_dice(op_s, r, n))
         };
         Ok(out.into_series())
     } else if ca1.len() == ca2.len() {
         let out: Float64Chunked = if parallel {
             ca1.par_iter_indexed()
                 .zip(ca2.par_iter_indexed())
-                .map(|(op_w1, op_w2)| optional_str_jaccard(op_w1, op_w2, n))
+                .map(|(op_w1, op_w2)| optional_sorensen_dice(op_w1, op_w2, n))
                 .collect()
         } else {
-            binary_elementwise_values(ca1, ca2, |x, y| str_jaccard(x, y, n))
+            binary_elementwise_values(ca1, ca2, |x, y| sorensen_dice(x, y, n))
         };
         Ok(out.into_series())
     } else {

--- a/src/str_ext/sorensen_dice.rs
+++ b/src/str_ext/sorensen_dice.rs
@@ -5,6 +5,8 @@ use pyo3_polars::{
     export::polars_core::utils::rayon::prelude::{IndexedParallelIterator, ParallelIterator},
 };
 
+// This is a different implementation than Sorensen Dice from strsim package.
+
 fn sorensen_dice(w1: &str, w2: &str, n: usize) -> f64 {
     let (s1, s2, intersect) = str_set_sim_helper(w1, w2, n);
     ((2 * intersect) as f64) / ((s1 + s2) as f64)

--- a/tests/test.ipynb
+++ b/tests/test.ipynb
@@ -18,10 +18,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pl.DataFrame({\n",
-    "    \"a\":[[\"a\", \"b\", \"c\"], [\"b\",\"c\"]]\n",
-    "    , \"b\": [[\"a\",\"b\"], [\"c\"]]\n",
-    "})"
+    "df = pl.DataFrame({\"a\": [\"kitten\", \"mary\", \"may\"], \"b\": [\"sitting\", \"merry\", \"mayer\"]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "4/11"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.select(\n",
+    "    pl.col(\"a\").str_ext.sorensen_dice(pl.col(\"b\"))\n",
+    ")"
    ]
   },
   {

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -228,20 +228,94 @@ def test_hamming_dist(df, res):
             pl.DataFrame({"a": ["kitten", "mary", "may"], "b": ["sitting", "merry", "mayer"]}),
             pl.DataFrame({"a": pl.Series([3, 2, 2], dtype=pl.UInt32)}),
         ),
+        (
+            pl.DataFrame(
+                {
+                    "a": [
+                        "Ostroróg",
+                        "Hätönen",
+                        "Kõivsaar",
+                        "Pöitel",
+                        "Vystrčil",
+                        "Särki",
+                        "Chreptavičienė",
+                        "Väänänen",
+                        "Führus",
+                        "Könönen",
+                        "Väänänen",
+                        "Łaszczyński",
+                        "Pärnselg",
+                        "Könönen",
+                        "Piątkowski",
+                        "D’Amore",
+                        "Körber",
+                        "Särki",
+                        "Kärson",
+                        "Węgrzyn",
+                    ],
+                    "b": [
+                        "Könönen",
+                        "Hätönen",
+                        "Wyżewski",
+                        "Jäger",
+                        "Hätönen",
+                        "Mäns",
+                        "Chreptavičienė",
+                        "Väänänen",
+                        "Ahısha",
+                        "Jürist",
+                        "Vainjärv",
+                        "Łaszczyński",
+                        "Pärnselg",
+                        "Führus",
+                        "Kübarsepp",
+                        "Németi",
+                        "Räheso",
+                        "Käri",
+                        "Jäger",
+                        "Setälä",
+                    ],
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "a": pl.Series(
+                        [8, 0, 8, 5, 7, 4, 0, 0, 6, 7, 6, 0, 0, 7, 10, 6, 6, 2, 5, 7],
+                        dtype=pl.UInt32,
+                    )
+                }
+            ),
+        ),
     ],
 )
-def test_levenshtein_dist(df, res):
-    assert_frame_equal(df.select(pl.col("a").str_ext.levenshtein_dist(pl.col("b"))), res)
+def test_levenshtein(df, res):
+    assert_frame_equal(df.select(pl.col("a").str_ext.levenshtein(pl.col("b"))), res)
+
+    assert_frame_equal(df.select(pl.col("a").str_ext.levenshtein(pl.col("b"), parallel=True)), res)
 
     assert_frame_equal(
-        df.select(pl.col("a").str_ext.levenshtein_dist(pl.col("b"), parallel=True)), res
+        df.lazy().select(pl.col("a").str_ext.levenshtein(pl.col("b"))).collect(), res
     )
+
+
+@pytest.mark.parametrize(
+    "df, res",
+    [
+        (
+            pl.DataFrame({"a": ["kitten"], "b": ["sitting"]}),
+            pl.DataFrame({"a": pl.Series([4 / 11], dtype=pl.Float64)}),
+        ),
+    ],
+)
+def test_sorensen_dice(df, res):
+    assert_frame_equal(df.select(pl.col("a").str_ext.sorensen_dice(pl.col("b"))), res)
+
     assert_frame_equal(
-        df.select(pl.col("a").str_ext.levenshtein_dist("may")),
-        pl.DataFrame({"a": pl.Series([6, 1, 0], dtype=pl.UInt32)}),
+        df.select(pl.col("a").str_ext.sorensen_dice(pl.col("b"), parallel=True)), res
     )
+
     assert_frame_equal(
-        df.lazy().select(pl.col("a").str_ext.levenshtein_dist(pl.col("b"))).collect(), res
+        df.lazy().select(pl.col("a").str_ext.sorensen_dice(pl.col("b"))).collect(), res
     )
 
 


### PR DESCRIPTION
1. Use strsim as backend for some string ops. This is a temporary solution to cover more features. strsim crate is no longer maintained. So we need to think about alternatives.
2. Added similarity version for Levenshtein and Damerau Levenshtein, Jaro similarity
3. Levenshtein now works with non-latin characters, is faster than before, but much slower than RapidFuzz. It is only 20%-30% faster than RapidFuzz when setting parallel =True. I suspect RapidFuzz is doing some SIMD on chars, which is quite sophisticated.
4.  Added more str similarity metrics such as Sorensen dice, overlap coefficient, etc. These currently works with &[u8] under the hood, not characters. so may not make sense for non-latin characters.
5. Initial work on integrating Aho-Corasick's matching + replacement
6. Added some tests 