### PR TITLE
Fix regex `SyntaxWarning` on Python 3.12+

### DIFF
--- a/python/polars_ds/str2.py
+++ b/python/polars_ds/str2.py
@@ -90,7 +90,7 @@ class StrExt:
             expr = expr.str.replace_all(",", "")
 
         # Find all numbers
-        expr = expr.str.extract_all("(\d*\.?\d+)")
+        expr = expr.str.extract_all(r"(\d*\.?\d+)")
         if dtype in pl.NUMERIC_DTYPES:
             expr = expr.list.eval(pl.element().cast(dtype))
         elif dtype == pl.String:  # As a list of strings


### PR DESCRIPTION
This fixes the following warning with `polars-ds==0.3.5` on Python 3.12+:

```
[...]/polars_ds/str2.py:91: SyntaxWarning: invalid escape sequence '\d'
  expr = expr.str.extract_all("(\d*\.?\d+)")
```