### PR TITLE
Skip some rows in KNN

### DIFF
--- a/python/polars_ds/num.py
+++ b/python/polars_ds/num.py
@@ -440,6 +440,7 @@ def query_principal_components(
 def query_knn_ptwise(
     *features: StrOrExpr,
     index: StrOrExpr,
+    skip_index: Optional[StrOrExpr] = None,
     k: int = 5,
     leaf_size: int = 32,
     dist: Distance = "l2",
@@ -483,6 +484,8 @@ def query_knn_ptwise(
     idx = str_to_expr(index).cast(pl.UInt32)
     metric = str(dist).lower()
     cols = [idx]
+    if skip_index is not None:
+        cols.append(str_to_expr(skip_index))
     cols.extend(str_to_expr(x) for x in features)
     if return_dist:
         return pl_plugin(


### PR DESCRIPTION
I have a use case where I need to find K nearest neighbors for a subset of N rows among M total rows.
My K and M are quite large: K = 5000, M = 300000, N = 50000 (just 1/6 of M).
Running KNN on all M rows uses too much memory.

I suggest to add an optional boolean column to indicate if rows should be excluded from calculation.
When the column is not there, there is just an additional Option check for every row.
When it's there, I allocate builders with 0 capacity, to conserve memory and push nulls for skipped rows.

A side change: the value capacity for `pl_knn_ptwise_w_dist` parallel was `8` which I changed to be in line with the other code branches.
