### PR TITLE
Fix overflow in generating Chi2 expected contingency table

### DIFF
--- a/src/stats/chi2.rs
+++ b/src/stats/chi2.rs
@@ -37,7 +37,7 @@ fn _chi2(inputs: &[Series]) -> PolarsResult<(LazyFrame, usize, usize)> {
     let df3 = df!(s1_name => s1, s2_name => s2)?
         .lazy()
         .group_by([col(s1_name), col(s2_name)])
-        .agg([len().alias("ob")]);
+        .agg([len().cast(DataType::UInt64).alias("ob")]);
 
     let df4 = cross
         .join(

--- a/tests/test_many.py
+++ b/tests/test_many.py
@@ -1347,9 +1347,17 @@ def test_welch_t(df):
                 }
             )
         ),
+        (
+            pl.DataFrame(
+                {
+                    "x": np.random.RandomState(42).permutation([0] * 2**16 + [1] * 2**16),
+                    "y": np.random.RandomState(43).permutation([0] * 2**16 + [1] * 2**16),
+                }
+            )
+        )
     ],
 )
-def test_chi2(df):
+def test_chi2(df: pl.DataFrame):
     import pandas as pd
     from scipy.stats import chi2_contingency
 
@@ -1358,7 +1366,7 @@ def test_chi2(df):
 
     df2 = df.to_pandas()
     contigency = pd.crosstab(index=df2["x"], columns=df2["y"])
-    sp_res = chi2_contingency(contigency.to_numpy(), correction=True)
+    sp_res = chi2_contingency(contigency.to_numpy(), correction=False)
     sp_stats, sp_p = sp_res.statistic, sp_res.pvalue
     assert np.isclose(stats, sp_stats)
     assert np.isclose(p, sp_p)


### PR DESCRIPTION
Casting the observed table to `Uint64` fixes the overflow.
Added a test to check it's working (doesn't pass in the current version).