### PR TITLE
Ndcg score based on previous work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "polars_ds"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_ds"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ numpy = "0.23" # matrix interop
 pyo3 = {version = "0.23", features = ["abi3-py39", "extension-module"]}
 pyo3-polars = {version = "0.20", features = ["derive", "dtype-array", "dtype-struct"]}
 # Polars
-polars = {version = "0.46", features = ["performant", "lazy",
+polars = {version = "0.46", features = ["performant", "lazy", "range",
 "diff", "array_count", "abs", "cross_join", "rank", "ndarray", "log", 
 "cum_agg", "round_series", "nightly","dtype-array", "dtype-struct", "dtype-i128"], default-features = false}
 polars-arrow = "0.46.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ numpy = "0.23" # matrix interop
 pyo3 = {version = "0.23", features = ["abi3-py39", "extension-module"]}
 pyo3-polars = {version = "0.20", features = ["derive", "dtype-array", "dtype-struct"]}
 # Polars
-polars = {version = "0.46", features = ["performant", "lazy", "range",
+polars = {version = "0.46", features = ["performant", "lazy",
 "diff", "array_count", "abs", "cross_join", "rank", "ndarray", "log", 
 "cum_agg", "round_series", "nightly","dtype-array", "dtype-struct", "dtype-i128"], default-features = false}
 polars-arrow = "0.46.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "polars_ds"
 requires-python = ">=3.9"
-version = "0.8.3"
+version = "0.9.0"
 
 license = { file = "LICENSE.txt" }
 classifiers = [

--- a/python/polars_ds/exprs/num.py
+++ b/python/polars_ds/exprs/num.py
@@ -54,6 +54,7 @@ __all__ = [
     "next_down",
     "digamma",
     "xlogy",
+    "add_at",
     "l_inf_horizontal",
     "l1_horizontal",
     "l2_sq_horizontal",
@@ -1063,12 +1064,33 @@ def next_down(x: str | pl.Expr) -> pl.Expr:
 
 def digamma(x: str | pl.Expr) -> pl.Expr:
     """
-    The diagamma function
+    The diagamma function.
     """
     return pl_plugin(
         symbol="pl_diagamma",
         args=[str_to_expr(x)],
         is_elementwise=True,
+    )
+
+
+def add_at(indices: str | pl.Expr, values: str | pl.Expr) -> pl.Expr:
+    """
+    Creates a zero column first. Then the j-th value in `values` will be added to
+    the j-th index in `indices`. This is the equivalent to NumPy's add.at.
+
+    Parameters
+    ----------
+    indices
+        Expression or name of a column. Must be castable to u32.
+    values
+        Expression or name of a column. Must be castable to f64 and have the same length
+        as the indices.
+    """
+    ind = str_to_expr(indices).cast(pl.UInt32).rechunk()
+    val = str_to_expr(values).cast(pl.Float64).rechunk()
+    return pl_plugin(
+        symbol="pl_add_at",
+        args=[ind, val],
     )
 
 

--- a/src/linalg/lr_solvers.rs
+++ b/src/linalg/lr_solvers.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 use super::{LRSolverMethods, LinalgErrors, LinearRegression};
-use faer::{Side, linalg::solvers::Solve, mat::Mat, prelude::*};
+use faer::{linalg::solvers::Solve, mat::Mat, prelude::*, Side};
 use faer_traits::RealField;
 use num::Float;
 

--- a/src/num_ext/float_extras.rs
+++ b/src/num_ext/float_extras.rs
@@ -5,7 +5,6 @@ use crate::stats_utils::gamma::digamma;
 use crate::utils::{first_field_output, float_output};
 use arity::binary_elementwise_values;
 use num::traits::Float;
-use polars::prelude::buffer::validate_utf8;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 
@@ -306,8 +305,7 @@ fn pl_diagamma(inputs: &[Series]) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn pl_add_at(inputs: &[Series]) -> PolarsResult<Series> {
-
-    // an equivalent function to numpy add at 
+    // an equivalent function to numpy add at
     // but only for f64 dtype
     // The data type + one-chunk-ness should be gauranteed in Python
 
@@ -315,30 +313,30 @@ fn pl_add_at(inputs: &[Series]) -> PolarsResult<Series> {
     let values = inputs[1].f64().unwrap();
     let buffer_size = inputs[2].u32().unwrap();
     let buffer_size = buffer_size
-        .get(0).map(|u| u as usize).unwrap_or(
-        indices.n_unique().unwrap_or_default()
-    );
+        .get(0)
+        .map(|u| u as usize)
+        .unwrap_or(indices.n_unique().unwrap_or_default());
 
     if buffer_size == 0 {
         return Err(PolarsError::ComputeError(
             "Buffer size cannot be 0 or indices is emtpy.".into(),
-        )) 
+        ));
     }
 
     let imax = indices.max().unwrap_or(0) as usize;
     if imax >= buffer_size {
         return Err(PolarsError::ComputeError(
             "Max index is >= buffer size.".into(),
-        )) 
+        ));
     }
 
     if indices.len() != values.len() {
         Err(PolarsError::ComputeError(
             "Indices and values don't have the same length.".into(),
-        )) 
+        ))
     } else {
         let mut output = vec![0f64; buffer_size];
-        let indices_slice = indices.cont_slice().unwrap(); 
+        let indices_slice = indices.cont_slice().unwrap();
         let values_slice = values.cont_slice().unwrap();
 
         for (i, v) in indices_slice.iter().zip(values_slice.iter()) {

--- a/src/num_ext/mod.rs
+++ b/src/num_ext/mod.rs
@@ -22,4 +22,5 @@ mod tp_fp;
 mod trapz;
 mod welch;
 mod woe_iv;
+
 // mod ball_tree;

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -241,68 +241,91 @@ def test_log_loss():
     res = df.select(pds.query_log_loss("y", "x")).item(0, 0)
     ans = log_loss(df["y"].to_numpy(), df["x"].to_numpy())
     assert np.isclose(res, ans, rtol=1e-10)
-    
-    
 
 
-def test_calculate_ndcg():
-    import numpy as np
-    import polars as pl
-    from sklearn.metrics import ndcg_score
-    import pytest
+def test_dcg_score():
+    from sklearn.metrics import dcg_score
 
-    from polars_ds.exprs.metrics import calculate_ndcg
-    # Create test data
-    data = {
-        'example_id': [1, 1, 1, 2, 2, 2, 3, 3],
-        'relevance': [3, 2, 1, 0, 1, 2, 2, 1],
-        'score': [0.9, 0.8, 0.7, 0.4, 0.5, 0.6, 0.8, 0.7]
-    }
-    df = pl.DataFrame(data)
+    df = pds.frame(size=1000, index_name="id").with_columns(
+        pl.col("id").mod(3).alias("example_id"),
+        pds.random_int(0, 10).alias("relevance"),
+        pds.random().alias("score"),
+    )
 
-    # Calculate NDCG using our implementation
-    result = calculate_ndcg(df, 'relevance', 'score', 'example_id')
-    
-    # Calculate NDCG per group using sklearn and then average
-    
-    
-    # Average NDCG across groups
-    df_pandas = df.to_pandas()
-    sklearn_ndcg = df_pandas.groupby('example_id').apply(lambda x: ndcg_score([x['relevance']], [x['score']])).mean()
-    
-    # Compare results (allowing for small numerical differences)
-    np.testing.assert_allclose(result.item(), sklearn_ndcg, rtol=1e-5)
+    df_agg = (
+        df.group_by("example_id")
+        .agg(dcg_score=pds.query_dcg_score("relevance", "score", ignore_ties=False))
+        .sort("example_id")
+    )
 
-    # Test with k parameter
-    k = 2
-    result_k = calculate_ndcg(df, 'relevance', 'score', 'example_id', k=k)
-    
-    # Calculate NDCG per group with k parameter and then average
-    group_ndcgs_k = []
-    for group_id in sorted(set(data['example_id'])):
-        group_mask = [i == group_id for i in data['example_id']]
-        group_relevance = [r for r, m in zip(data['relevance'], group_mask) if m]
-        group_score = [s for s, m in zip(data['score'], group_mask) if m]
-        
-        # Calculate NDCG for this group with k
-        group_ndcg = ndcg_score([group_relevance], [group_score], k=k)
-        group_ndcgs_k.append(group_ndcg)
-    
-    # Average NDCG across groups
-    sklearn_ndcg_k = np.mean(group_ndcgs_k)
-    np.testing.assert_allclose(result_k.item(), sklearn_ndcg_k, rtol=1e-5)
+    sklearn_results = []
+    for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
+        rel = subdf["relevance"].to_numpy().reshape((1, -1))
+        score = subdf["score"].to_numpy().reshape((1, -1))
+        sklearn_results.append(dcg_score(rel, score, ignore_ties=False))
 
-    # Test with ties
-    data_with_ties = {
-        'example_id': [1, 1, 1, 2, 2, 2],
-        'relevance': [3, 2, 1, 2, 2, 1],
-        'score': [0.9, 0.9, 0.7, 0.8, 0.8, 0.6]
-    }
-    df_ties = pl.DataFrame(data_with_ties)
-    
-    # Test both with and without ignore_ties
-    result_with_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=True)
-    result_without_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=False)
-    
-    # The results should be different when handling ties differently
-    assert result_with_ties.item() != result_without_ties.item() 
+    sklearn_results = np.array(sklearn_results)
+
+    np.testing.assert_allclose(df_agg["dcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
+
+
+# def test_calculate_ndcg():
+#     import numpy as np
+#     import polars as pl
+#     from sklearn.metrics import ndcg_score
+
+#     from polars_ds.exprs.metrics import calculate_ndcg
+#     # Create test data
+#     data = {
+#         'example_id': [1, 1, 1, 2, 2, 2, 3, 3],
+#         'relevance': [3, 2, 1, 0, 1, 2, 2, 1],
+#         'score': [0.9, 0.8, 0.7, 0.4, 0.5, 0.6, 0.8, 0.7]
+#     }
+#     df = pl.DataFrame(data)
+
+#     # Calculate NDCG using our implementation
+#     result = calculate_ndcg(df, 'relevance', 'score', 'example_id')
+
+#     # Calculate NDCG per group using sklearn and then average
+
+
+#     # Average NDCG across groups
+#     df_pandas = df.to_pandas()
+#     sklearn_ndcg = df_pandas.groupby('example_id').apply(lambda x: ndcg_score([x['relevance']], [x['score']])).mean()
+
+#     # Compare results (allowing for small numerical differences)
+#     np.testing.assert_allclose(result.item(), sklearn_ndcg, rtol=1e-5)
+
+#     # Test with k parameter
+#     k = 2
+#     result_k = calculate_ndcg(df, 'relevance', 'score', 'example_id', k=k)
+
+#     # Calculate NDCG per group with k parameter and then average
+#     group_ndcgs_k = []
+#     for group_id in sorted(set(data['example_id'])):
+#         group_mask = [i == group_id for i in data['example_id']]
+#         group_relevance = [r for r, m in zip(data['relevance'], group_mask) if m]
+#         group_score = [s for s, m in zip(data['score'], group_mask) if m]
+
+#         # Calculate NDCG for this group with k
+#         group_ndcg = ndcg_score([group_relevance], [group_score], k=k)
+#         group_ndcgs_k.append(group_ndcg)
+
+#     # Average NDCG across groups
+#     sklearn_ndcg_k = np.mean(group_ndcgs_k)
+#     np.testing.assert_allclose(result_k.item(), sklearn_ndcg_k, rtol=1e-5)
+
+#     # Test with ties
+#     data_with_ties = {
+#         'example_id': [1, 1, 1, 2, 2, 2],
+#         'relevance': [3, 2, 1, 2, 2, 1],
+#         'score': [0.9, 0.9, 0.7, 0.8, 0.8, 0.6]
+#     }
+#     df_ties = pl.DataFrame(data_with_ties)
+
+#     # Test both with and without ignore_ties
+#     result_with_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=True)
+#     result_without_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=False)
+
+#     # The results should be different when handling ties differently
+#     assert result_with_ties.item() != result_without_ties.item()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -252,80 +252,78 @@ def test_dcg_score():
         pds.random().alias("score"),
     )
 
-    df_agg = (
-        df.group_by("example_id")
-        .agg(dcg_score=pds.query_dcg_score("relevance", "score", ignore_ties=False))
-        .sort("example_id")
+    for tie in [True, False]:
+        df_agg = (
+            df.group_by("example_id")
+            .agg(dcg_score=pds.query_dcg_score("relevance", "score", ignore_ties=tie))
+            .sort("example_id")
+        )
+
+        sklearn_results = []
+        for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
+            rel = subdf["relevance"].to_numpy().reshape((1, -1))
+            score = subdf["score"].to_numpy().reshape((1, -1))
+            sklearn_results.append(dcg_score(rel, score, ignore_ties=tie))
+
+        sklearn_results = np.array(sklearn_results)
+
+        np.testing.assert_allclose(df_agg["dcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
+
+    for k in range(1, 5):
+        df_agg = (
+            df.group_by("example_id")
+            .agg(dcg_score=pds.query_dcg_score("relevance", "score", k=k, ignore_ties=False))
+            .sort("example_id")
+        )
+
+        sklearn_results = []
+        for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
+            rel = subdf["relevance"].to_numpy().reshape((1, -1))
+            score = subdf["score"].to_numpy().reshape((1, -1))
+            sklearn_results.append(dcg_score(rel, score, k=k, ignore_ties=False))
+
+        sklearn_results = np.array(sklearn_results)
+
+        np.testing.assert_allclose(df_agg["dcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
+
+
+def test_ndcg_score():
+    from sklearn.metrics import ndcg_score
+
+    df = pds.frame(size=1000, index_name="id").with_columns(
+        pl.col("id").mod(3).alias("example_id"),
+        pds.random_int(0, 10).alias("relevance"),
+        pds.random().alias("score"),
     )
 
-    sklearn_results = []
-    for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
-        rel = subdf["relevance"].to_numpy().reshape((1, -1))
-        score = subdf["score"].to_numpy().reshape((1, -1))
-        sklearn_results.append(dcg_score(rel, score, ignore_ties=False))
+    for tie in [True, False]:
+        df_agg = (
+            df.group_by("example_id")
+            .agg(ndcg_score=pds.query_ndcg_score("relevance", "score", ignore_ties=tie))
+            .sort("example_id")
+        )
 
-    sklearn_results = np.array(sklearn_results)
+        sklearn_results = []
+        for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
+            rel = subdf["relevance"].to_numpy().reshape((1, -1))
+            score = subdf["score"].to_numpy().reshape((1, -1))
+            sklearn_results.append(ndcg_score(rel, score, ignore_ties=tie))
 
-    np.testing.assert_allclose(df_agg["dcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
+        sklearn_results = np.array(sklearn_results)
+        np.testing.assert_allclose(df_agg["ndcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
 
+    for k in range(1, 5):
+        df_agg = (
+            df.group_by("example_id")
+            .agg(ndcg_score=pds.query_ndcg_score("relevance", "score", k=k, ignore_ties=False))
+            .sort("example_id")
+        )
 
-# def test_calculate_ndcg():
-#     import numpy as np
-#     import polars as pl
-#     from sklearn.metrics import ndcg_score
+        sklearn_results = []
+        for by, subdf in df.sort("example_id").partition_by("example_id", as_dict=True).items():
+            rel = subdf["relevance"].to_numpy().reshape((1, -1))
+            score = subdf["score"].to_numpy().reshape((1, -1))
+            sklearn_results.append(ndcg_score(rel, score, k=k, ignore_ties=False))
 
-#     from polars_ds.exprs.metrics import calculate_ndcg
-#     # Create test data
-#     data = {
-#         'example_id': [1, 1, 1, 2, 2, 2, 3, 3],
-#         'relevance': [3, 2, 1, 0, 1, 2, 2, 1],
-#         'score': [0.9, 0.8, 0.7, 0.4, 0.5, 0.6, 0.8, 0.7]
-#     }
-#     df = pl.DataFrame(data)
-
-#     # Calculate NDCG using our implementation
-#     result = calculate_ndcg(df, 'relevance', 'score', 'example_id')
-
-#     # Calculate NDCG per group using sklearn and then average
-
-
-#     # Average NDCG across groups
-#     df_pandas = df.to_pandas()
-#     sklearn_ndcg = df_pandas.groupby('example_id').apply(lambda x: ndcg_score([x['relevance']], [x['score']])).mean()
-
-#     # Compare results (allowing for small numerical differences)
-#     np.testing.assert_allclose(result.item(), sklearn_ndcg, rtol=1e-5)
-
-#     # Test with k parameter
-#     k = 2
-#     result_k = calculate_ndcg(df, 'relevance', 'score', 'example_id', k=k)
-
-#     # Calculate NDCG per group with k parameter and then average
-#     group_ndcgs_k = []
-#     for group_id in sorted(set(data['example_id'])):
-#         group_mask = [i == group_id for i in data['example_id']]
-#         group_relevance = [r for r, m in zip(data['relevance'], group_mask) if m]
-#         group_score = [s for s, m in zip(data['score'], group_mask) if m]
-
-#         # Calculate NDCG for this group with k
-#         group_ndcg = ndcg_score([group_relevance], [group_score], k=k)
-#         group_ndcgs_k.append(group_ndcg)
-
-#     # Average NDCG across groups
-#     sklearn_ndcg_k = np.mean(group_ndcgs_k)
-#     np.testing.assert_allclose(result_k.item(), sklearn_ndcg_k, rtol=1e-5)
-
-#     # Test with ties
-#     data_with_ties = {
-#         'example_id': [1, 1, 1, 2, 2, 2],
-#         'relevance': [3, 2, 1, 2, 2, 1],
-#         'score': [0.9, 0.9, 0.7, 0.8, 0.8, 0.6]
-#     }
-#     df_ties = pl.DataFrame(data_with_ties)
-
-#     # Test both with and without ignore_ties
-#     result_with_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=True)
-#     result_without_ties = calculate_ndcg(df_ties, 'relevance', 'score', 'example_id', ignore_ties=False)
-
-#     # The results should be different when handling ties differently
-#     assert result_with_ties.item() != result_without_ties.item()
+        sklearn_results = np.array(sklearn_results)
+        np.testing.assert_allclose(df_agg["ndcg_score"].to_numpy(), sklearn_results, rtol=1e-5)


### PR DESCRIPTION
This PR builds on the previous implementation and turns ndcg score into pure Polars expressions which is more optimized and can be used in lazy context. 

Now the `group_col` argument is dropped in favor of a more straightforward implementation. For an overall evaluation of the score (across all groups), the user should run the score in a group by context and average the score themselves. 

 