### PR TITLE
feat: Implement Generalized Linear Modesl (GLMS) with IRLS Solver [DRAFT]

### DIFF
--- a/src/linalg/glm_solvers.rs
+++ b/src/linalg/glm_solvers.rs
@@ -1,0 +1,390 @@
+#![allow(non_snake_case)]
+use super::{
+    link_functions::{LinkFunction, VarianceFunction},
+    LinalgErrors, lr_solvers::faer_weighted_lstsq, LRSolverMethods, GLMSolverMethods,
+    GeneralizedLinearModel,
+};
+use faer::{mat::Mat, MatRef};
+use faer_traits::RealField;
+use num::Float;
+
+/// Methods supported by the GLM solver
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GLMFamily {
+    Gaussian,
+    Poisson,
+    Binomial,
+    Gamma,
+    Custom(LinkFunction, VarianceFunction),
+}
+
+impl GLMFamily {
+    pub fn link_function(&self) -> LinkFunction {
+        match self {
+            GLMFamily::Gaussian => LinkFunction::Identity,
+            GLMFamily::Poisson => LinkFunction::Log,
+            GLMFamily::Binomial => LinkFunction::Logit,
+            GLMFamily::Gamma => LinkFunction::Inverse,
+            GLMFamily::Custom(link, _) => *link,
+        }
+    }
+    
+    pub fn variance_function(&self) -> VarianceFunction {
+        match self {
+            GLMFamily::Gaussian => VarianceFunction::Gaussian,
+            GLMFamily::Poisson => VarianceFunction::Poisson,
+            GLMFamily::Binomial => VarianceFunction::Binomial,
+            GLMFamily::Gamma => VarianceFunction::Gamma,
+            GLMFamily::Custom(_, var) => *var,
+        }
+    }
+}
+
+impl From<&str> for GLMFamily {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "gaussian" | "normal" => GLMFamily::Gaussian,
+            "poisson" => GLMFamily::Poisson,
+            "binomial" | "logistic" => GLMFamily::Binomial,
+            "gamma" => GLMFamily::Gamma,
+            _ => GLMFamily::Gaussian, // Default to Gaussian
+        }
+    }
+}
+
+/// Parameters for the IRLS algorithm
+pub struct IRLSParams<T: RealField + Float> {
+    pub tol: T,
+    pub max_iter: usize,
+}
+
+impl<T: RealField + Float> Default for IRLSParams<T> {
+    fn default() -> Self {
+        IRLSParams {
+            tol: T::from(1e-6).unwrap(),
+            max_iter: 100,
+        }
+    }
+}
+
+/// Generalized Linear Model implementation supporting various link and variance functions
+pub struct GLM<T: RealField + Float> {
+    pub solver: GLMSolverMethods,
+    pub lambda: T,
+    pub coefficients: Mat<T>, // n_features x 1 matrix, doesn't contain bias
+    pub has_bias: bool,
+    pub link: LinkFunction,
+    pub variance: VarianceFunction,
+    pub irls_params: IRLSParams<T>,
+}
+
+impl<T: RealField + Float> GLM<T> {
+    pub fn new(solver: &str, lambda: T, has_bias: bool, link: LinkFunction, variance: VarianceFunction) -> Self {
+        GLM {
+            solver: solver.into(),
+            lambda,
+            coefficients: Mat::new(),
+            has_bias,
+            link,
+            variance,
+            irls_params: IRLSParams::default(),
+        }
+    }
+    
+    /// Create a new GLM with a specified family that determines the link and variance functions
+    pub fn new_with_family(solver: &str, lambda: T, has_bias: bool, family: GLMFamily) -> Self {
+        GLM {
+            solver: solver.into(),
+            lambda,
+            coefficients: Mat::new(),
+            has_bias,
+            link: family.link_function(),
+            variance: family.variance_function(),
+            irls_params: IRLSParams::default(),
+        }
+    }
+
+    pub fn set_link_function(&mut self, link: LinkFunction) {
+        self.link = link;
+    }
+
+    pub fn set_variance_function(&mut self, variance: VarianceFunction) {
+        self.variance = variance;
+    }
+    
+    pub fn set_family(&mut self, family: GLMFamily) {
+        self.link = family.link_function();
+        self.variance = family.variance_function();
+    }
+
+    pub fn set_solver(&mut self, solver: &str) {
+        self.solver = solver.into();
+    }
+    
+    pub fn set_irls_params(&mut self, tol: T, max_iter: usize) {
+        self.irls_params.tol = tol;
+        self.irls_params.max_iter = max_iter;
+    }
+    
+    pub fn set_coeffs_and_bias(&mut self, coeffs: &[T], bias: T) {
+        self.has_bias = bias.abs() > T::epsilon();
+        if self.has_bias {
+            self.coefficients = Mat::from_fn(coeffs.len() + 1, 1, |i, _| {
+                if i < coeffs.len() {
+                    coeffs[i]
+                } else {
+                    bias
+                }
+            })
+        } else {
+            self.coefficients = faer::ColRef::<T>::from_slice(coeffs).as_mat().to_owned();
+        }
+    }
+    
+    /// Get the current link function
+    pub fn link_function(&self) -> LinkFunction {
+        self.link
+    }
+    
+    /// Get the current variance function
+    pub fn variance_function(&self) -> VarianceFunction {
+        self.variance
+    }
+}
+
+impl<T: RealField + Float> GeneralizedLinearModel<T> for GLM<T> {
+    fn fitted_values(&self) -> MatRef<T> {
+        self.coefficients.as_ref()
+    }
+
+    fn has_bias(&self) -> bool {
+        self.has_bias
+    }
+
+    fn fit_unchecked(&mut self, X: MatRef<T>, y: MatRef<T>) {
+        self.coefficients = faer_irls(
+            X, 
+            y, 
+            self.link,
+            self.variance,
+            self.lambda,
+            LRSolverMethods::QR,
+            self.has_bias,
+            &self.irls_params
+        );
+    }
+}
+
+/// Implements the Iteratively Reweighted Least Squares algorithm for GLMs
+/// 
+/// # Arguments
+/// * `X` - Design matrix
+/// * `y` - Response vector
+/// * `link` - Link function
+/// * `variance` - Variance function
+/// * `lambda` - L2 regularization parameter (Ridge penalty)
+/// * `solver_method` - Method to solve the weighted least squares problem
+/// * `has_bias` - Whether to include a bias term
+/// * `params` - IRLS parameters (tolerance and max iterations)
+/// 
+/// # Returns
+/// * Coefficients matrix (including bias if requested)
+#[inline(always)]
+pub fn faer_irls<T: RealField + Float>(
+    X: MatRef<T>,
+    y: MatRef<T>,
+    link: LinkFunction,
+    variance: VarianceFunction,
+    lambda: T,
+    solver_method: LRSolverMethods,
+    has_bias: bool,
+    params: &IRLSParams<T>,
+) -> Mat<T> {
+    let n_samples = X.nrows();
+    let n_features = X.ncols();
+    
+    let mut beta: Mat<T>;
+    if has_bias {
+        beta = Mat::zeros(n_features + 1, 1);
+    } else {
+        beta = Mat::zeros(n_features, 1);
+    }
+    
+    let X_with_bias = if has_bias {
+        let ones = Mat::full(n_samples, 1, T::one());
+        faer::concat![[X, ones]]
+    } else {
+        X.to_owned()
+    };
+
+    let epsilon = T::from(1e-4).unwrap();
+    let mut mu = Mat::zeros(n_samples, 1);
+    for i in 0..n_samples {
+        let yi = *y.get(i, 0);
+        let adjusted_y = match variance {
+            VarianceFunction::Binomial => {
+                // For binomial, ensure y is between 0 and 1
+                yi.max(epsilon).min(T::one() - epsilon)
+            },
+            VarianceFunction::Poisson | VarianceFunction::Gamma => {
+                // Ensure positive for Poisson and Gamma
+                yi.max(epsilon)
+            },
+            _ => yi,
+        };
+        *unsafe { mu.get_mut_unchecked(i, 0) } = adjusted_y;
+    }
+    
+    // IRLS
+    let mut converged = false;
+    for _ in 0..params.max_iter {
+        // Step 1: Compute linear predictor (η) from current coefficients
+        let eta = &X_with_bias * &beta;
+        
+        // Step 2: Update mean estimate (μ) using the inverse link function
+        for i in 0..n_samples {
+            let eta_i = *eta.get(i, 0);
+            let mu_i = link.inv_link(eta_i);
+            *unsafe { mu.get_mut_unchecked(i, 0) } = mu_i;
+        }
+        
+        // Step 3: Compute weights and working response
+        let mut weights = Vec::with_capacity(n_samples);
+        let mut z = Mat::zeros(n_samples, 1);
+        
+        for i in 0..n_samples {
+            let mu_i = *mu.get(i, 0);
+            let y_i = *y.get(i, 0);
+            let eta_i = *eta.get(i, 0);
+            
+            // Derivative of the link function
+            let d_mu_i = link.link_deriv(mu_i);
+            
+            // Variance function
+            let v_mu_i = variance.variance(mu_i);
+            
+            // Weight: 1 / (link'(μ)² * V(μ))
+            let weight = if d_mu_i.abs() < T::from(1e-10).unwrap() || v_mu_i < T::from(1e-10).unwrap() {
+                T::from(1e10).unwrap() // Large but finite value
+            } else {
+                T::one() / (d_mu_i.powi(2) * v_mu_i)
+            };
+            
+            weights.push(weight);
+            
+            // Working response: η + (y - μ) * link'(μ)
+            let working_response = eta_i + (y_i - mu_i) * d_mu_i;
+            *unsafe { z.get_mut_unchecked(i, 0) } = working_response;
+        }
+        
+        // Step 4: Solve weighted least squares problem for new coefficients
+        let beta_new = faer_weighted_lstsq(X_with_bias.as_ref(), z.as_ref(), &weights, solver_method);
+        
+        // Check for convergence
+        let mut max_diff = T::zero();
+        for i in 0..beta.nrows() {
+            let diff = (*beta_new.get(i, 0) - *beta.get(i, 0)).abs();
+            if diff > max_diff {
+                max_diff = diff;
+            }
+        }
+        
+        // Update beta
+        beta = beta_new;
+        
+        // Check convergence
+        if max_diff < params.tol {
+            converged = true;
+            break;
+        }
+    }
+    
+    if !converged {
+        panic!("IRLS algorithm did not converge within maximum iterations");
+    }
+    
+    beta
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faer::assert_matrix_eq;
+
+    // Helper function to check if two f64 values are approximately equal
+    fn approx_eq(a: f64, b: f64, epsilon: f64) -> bool {
+        (a - b).abs() < epsilon
+    }
+
+    // Helper function to check if vectors are approximately equal
+    fn assert_approx_eq_vec(actual: &[f64], expected: &[f64], epsilon: f64) {
+        assert_eq!(actual.len(), expected.len(), "Vectors have different lengths");
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                approx_eq(*a, *e, epsilon),
+                "Elements at position {} differ significantly: {} vs {} (epsilon: {})",
+                i, a, e, epsilon
+            );
+        }
+    }
+    
+   
+    // Helper function to create Poisson data
+    fn create_poisson_test_data<T: RealField + Float>(n_samples: usize) -> (Mat<T>, Mat<T>) {
+        let mut X = Mat::zeros(n_samples, 2);
+        let mut y = Mat::zeros(n_samples, 1);
+        
+        let beta_true = [T::from(0.5).unwrap(), T::from(-0.3).unwrap()];
+        let intercept = T::from(1.0).unwrap();
+        
+        for i in 0..n_samples {
+            let x1 = T::from(i % 10).unwrap() / T::from(10).unwrap();
+            let x2 = T::from((i * 7) % 13).unwrap() / T::from(13).unwrap();
+            
+            *unsafe { X.get_mut_unchecked(i, 0) } = x1;
+            *unsafe { X.get_mut_unchecked(i, 1) } = x2;
+            
+            // Generate log(lambda) = intercept + beta1*x1 + beta2*x2
+            let log_lambda = intercept + beta_true[0] * x1 + beta_true[1] * x2;
+            let lambda = log_lambda.exp();
+            
+            let count = lambda.round();
+            *unsafe { y.get_mut_unchecked(i, 0) } = count;
+        }
+        
+        (X, y)
+    }
+    
+   
+    #[test]
+    fn test_glm_poisson() {
+        let (X, y) = create_poisson_test_data::<f64>(100);
+        
+        let mut glm = GLM::new_with_family("irls", 0.0, true, GLMFamily::Poisson);
+        
+        glm.set_irls_params(1e-8, 200);
+        
+        let result = glm.fit(X.as_ref(), y.as_ref());
+        assert!(result.is_ok());
+        
+        assert!(glm.is_fit());
+        
+        let coeffs = glm.coeffs_as_vec().unwrap();
+        let bias = glm.bias();
+        
+        assert_approx_eq_vec(&coeffs, &[0.5, -0.3], 0.8);
+        assert_approx_eq(bias, 1.0, 0.8);
+        
+        let linear_pred = glm.linear_predictor(X.as_ref()).unwrap();
+        
+        let mut expected_counts = Mat::zeros(linear_pred.nrows(), 1);
+        for i in 0..linear_pred.nrows() {
+            *unsafe { expected_counts.get_mut_unchecked(i, 0) } = linear_pred.get(i, 0).exp();
+        }
+        
+        for i in 0..expected_counts.nrows() {
+            assert!(*expected_counts.get(i, 0) >= 0.0);
+        }
+    }
+}
+ 

--- a/src/linalg/link_functions.rs
+++ b/src/linalg/link_functions.rs
@@ -1,0 +1,79 @@
+/// Defines the link functions for the GLM.
+use faer_traits::RealField;
+use num::Float;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LinkFunction {
+    Identity, // Normal
+    Log,      // Poisson
+    Logit,    // Binomial
+    Inverse,  // Gamma
+}
+
+impl LinkFunction {
+    /// g(μ)
+    pub fn link<T: RealField + Float>(&self, mu: T) -> T {
+        match self {
+            LinkFunction::Identity => mu,
+            LinkFunction::Log => mu.ln(),
+            LinkFunction::Logit => {
+                // logit(p) = ln(p/(1-p))
+                let one = T::one();
+                (mu / (one - mu)).ln()
+            },
+            LinkFunction::Inverse => mu.recip(),
+        }
+    }
+
+    /// g^(-1)(η)
+    pub fn inv_link<T: RealField + Float>(&self, eta: T) -> T {
+        match self {
+            LinkFunction::Identity => eta,
+            LinkFunction::Log => eta.exp(),
+            LinkFunction::Logit => {
+                // inv_logit(x) = exp(x)/(1+exp(x))
+                let one = T::one();
+                let exp_eta = eta.exp();
+                exp_eta / (one + exp_eta)
+            },
+            LinkFunction::Inverse => eta.recip(),
+        }
+    }
+
+    /// Computes g'(μ)
+    pub fn link_deriv<T: RealField + Float>(&self, mu: T) -> T {
+        match self {
+            LinkFunction::Identity => T::one(),
+            LinkFunction::Log => mu.recip(),
+            LinkFunction::Logit => {
+                // d/dp logit(p) = 1/(p(1-p))
+                let one = T::one();
+                one / (mu * (one - mu))
+            },
+            LinkFunction::Inverse => -mu.recip().powi(2),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VarianceFunction {
+    Gaussian,
+    Poisson,
+    Binomial,
+    Gamma,
+}
+
+impl VarianceFunction {
+    /// Variance(μ)
+    pub fn variance<T: RealField + Float>(&self, mu: T) -> T {
+        match self {
+            VarianceFunction::Gaussian => T::one(),
+            VarianceFunction::Poisson => mu,
+            VarianceFunction::Binomial => {
+                let one = T::one();
+                mu * (one - mu)
+            },
+            VarianceFunction::Gamma => mu.powi(2),
+        }
+    }
+}


### PR DESCRIPTION
Related To: #338 
This PR introduces the implementation of Generalized Linear Models (GLMs) using the Iteratively Reweighted Least Squares (IRLS) algorithm: [IRLS] (https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares). 
I am reusing existing implementation of weighted least squares at `ls_solvers::faer_weighted_lstsq`. 

### The implementation should:

1. Supports standard GLM families (Gaussian, Poisson, Binomial, Gamma) via the `GLMFamily` enum.
2. Allows specification of custom LinkFunction and VarianceFunction (defined in src/linalg/link_functions.rs).

### Usage:

```
glm_poisson = GLM(
    family="poisson",
    lambda_=0.01,
    has_bias=True,
    tol=1e-6,
    max_iter=100
)

# Custom Link and Variance
# glm_poisson = GLM(link="log", variance="poisson", lambda_=0.01, ...)

glm_poisson.fit(X, y)
glm_poisson.predict(X)
```

### TODOS:
1. Test common GLM family methods and using custom link function 
2. Add python bindings
3. Add unit tests for python implementation.
4. Clean up the code, Handle errors gracefully.

### Potentital Isses:
1. The LBFGS solver (GLMSolverMethods::LBFGS) is defined but not implemented; selecting it currently panics.
2. The internal solver method used within `faer_irls` (LRSolverMethods::QR) is currently hardcoded. This should ideally be passed down.
