### PR TITLE
welchs_t returns null if given invalid input

### DIFF
--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -10,11 +10,15 @@ mod xi_corr;
 
 use polars::prelude::*;
 
-pub fn simple_stats_output(_: &[Field]) -> PolarsResult<Field> {
+fn stats_output_dtype() -> DataType {
     let s = Field::new("statistic".into(), DataType::Float64);
     let p = Field::new("pvalue".into(), DataType::Float64);
     let v: Vec<Field> = vec![s, p];
-    Ok(Field::new("".into(), DataType::Struct(v)))
+    DataType::Struct(v)
+}
+
+pub fn simple_stats_output(_: &[Field]) -> PolarsResult<Field> {
+    Ok(Field::new("".into(), stats_output_dtype()))
 }
 
 pub enum Alternative {
@@ -40,4 +44,17 @@ fn generic_stats_output(statistic: f64, pvalue: f64) -> PolarsResult<Series> {
     let p = Series::from_vec("pvalue".into(), vec![pvalue]);
     let out = StructChunked::from_series("".into(), 1, [&s, &p].into_iter())?;
     Ok(out.into_series())
+}
+
+#[inline]
+fn generic_optional_stats_output(output: Option<(f64, f64)>) -> PolarsResult<Series> {
+    if let Some((statistic, pvalue)) = output {
+        let s = Series::from_vec("statistic".into(), vec![statistic]);
+        let p = Series::from_vec("pvalue".into(), vec![pvalue]);
+        let out = StructChunked::from_series("".into(), 1, [&s, &p].into_iter())?;
+        Ok(out.into_series())
+    } else {
+        let dtype = stats_output_dtype();
+        Ok(Series::full_null("".into(), 1, &dtype).into_series())
+    }
 }


### PR DESCRIPTION
As mentioned in #379, many of the rust functions panic when they get invalid inputs. Here's a first pass at addressing that for Welch's t-test. The change is for the lowest level function to return None if given invalid inputs (otherwise Some(statistics, p)). That results gets returned to python as a series with either a struct (for valid inputs) or null. Seem reasonable?