### PR TITLE
Removed is_elementwise from certain random generation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,13 @@ Generally speaking, the more expressions you want to evaluate simultaneously, th
 1. K-means, K-medoids clustering as expressions and also standalone modules.
 2. Other improvement items. See issues.
 
-# Disclaimer
+# Minimum Polars Support + Streaming Compatibility
 
-**Currently in Beta. Feel free to submit feature requests in the issues section of the repo. This library will only depend on python Polars (for most of its core) and will try to be as stable as possible for polars>=1. Exceptions will be made when Polars's update forces changes in the plugins.**
+**This library will only depend on python Polars (for most of its core) and will try to be as stable as possible for polars>=1.4.0. Exceptions will be made when Polars's update forces changes in the plugins. However, Polars updates quickly and older versions may not be tested. Currently, it is actively tested for Polars>=1.33.**
 
-This package is not tested with Polars streaming mode and is not designed to work with data so big that has to be streamed. This concerns the plugin expressions like `pds.lin_reg`, etc. By the same token, Polars large index version is not intentionally supported at this point. However, non-plugin Polars utilities provided by the function should work with the streaming engine, as they are native Polars code.
+This package is also not tested with Polars streaming mode and is not designed to work with data so big that has to be streamed. This concerns plugin expressions like `pds.lin_reg`, etc, which won't work with streaming. By the same token, Polars large index version is not supported at this point, and I welcome any 3rd packaging. However, I will try to support some expressions with the streaming engine, as they may be important.
 
-## Polars LTS CPU Support / Build From Source
+## Build From Source
 
 The guide here is not specific to LTS CPU, and can be used generally.
 
@@ -326,7 +326,3 @@ You can then publish it to your private PYPI server, or just use it locally.
 1. Some statistics functions are taken from Statrs (MIT) and internalized. See [here](https://github.com/statrs-dev/statrs/tree/master)
 2. Linear algebra routines are powered mostly by [faer](https://crates.io/crates/faer)
 3. String similarity metrics are soooo fast because of [RapidFuzz](https://github.com/maxbachmann/rapidfuzz-rs)
-
-# Other related Projects
-
-1. Take a look at our friendly neighbor [functime](https://github.com/TracecatHQ/functime)

--- a/python/polars_ds/exprs/stats.py
+++ b/python/polars_ds/exprs/stats.py
@@ -428,7 +428,7 @@ def perturb(
     return pl_plugin(
         symbol="pl_perturb",
         args=[to_expr(x), lo, hi, pl.lit(seed, dtype=pl.UInt64)],
-        is_elementwise=True,
+        is_elementwise=True
     )
 
 
@@ -458,7 +458,7 @@ def jitter(x: str | pl.Expr, std: float | pl.Expr = 1.0, seed: int | None = None
     return pl_plugin(
         symbol="pl_jitter",
         args=[to_expr(x), s, pl.lit(seed, dtype=pl.UInt64)],
-        is_elementwise=True,
+        is_elementwise=True
     )
 
 
@@ -540,7 +540,6 @@ def random(
     return pl_plugin(
         symbol="pl_random",
         args=[len_, lo, up, pl.lit(seed, pl.UInt64)],
-        is_elementwise=True,
     )
 
 
@@ -600,7 +599,6 @@ def random_int(
             hi,
             pl.lit(seed, pl.UInt64),
         ],
-        is_elementwise=True,
     )
 
 
@@ -637,7 +635,6 @@ def random_str(
             pl.lit(ma, pl.UInt32),
             pl.lit(seed, pl.UInt64),
         ],
-        is_elementwise=True,
     )
 
 
@@ -669,7 +666,6 @@ def random_binomial(
             pl.lit(p, pl.Float64),
             pl.lit(seed, pl.UInt64),
         ],
-        is_elementwise=True,
     )
 
 
@@ -695,7 +691,6 @@ def random_exp(
             pl.lit(lambda_, pl.Float64),
             pl.lit(seed, pl.UInt64),
         ],
-        is_elementwise=True,
     )
 
 
@@ -727,7 +722,6 @@ def random_normal(
             pl.lit(std, pl.Float64) if isinstance(std, float) else std,
             pl.lit(seed, pl.UInt64),
         ],
-        is_elementwise=True,
     )
 
 


### PR DESCRIPTION
```
ShapeError: could not create a new DataFrame: series "x1" has length 305 while trying to broadcast to length 5000 (matching column 'len')
```

When in streaming mode, and `is_elementwise=True`, the plugin will be evaluated for every chunk. However, we passed pl.len() which evaluates to len(df). Say len(df) = 5000, that means for every chunk we will get a random 5000 len series. Now when we collect each chunk, 1 series is of length 5000 and the other is of len 305, we got this error.

If `is_elementwise=False`, then the plugin is only evaluated once, in a non-streaming fashion which results in the correct output.

Removing this setting will resolve the issue. Will get some clarification from Polars as well. 

This resolves https://github.com/abstractqqq/polars_ds_extension/issues/409