### PR TITLE
[Enhancement]: cut lin_reg per-call overhead ~7× for many-small-groups workloads

### DIFF
--- a/benchmarks/parallelism_crossover.py
+++ b/benchmarks/parallelism_crossover.py
@@ -1,0 +1,223 @@
+"""
+Rayon-vs-sequential crossover benchmark for polars_ds.
+
+Purpose
+-------
+Find the input sizes at which parallel (rayon) execution becomes faster than
+sequential execution for two hot paths:
+
+  1. series_to_slice proxy  — column-copy overhead dominates at small sizes;
+     proxied by a flat (no group_by) pds.lin_reg() call with add_bias=True.
+  2. predict matmul proxy   — faer matrix-multiply; proxied by LR.predict() on
+     a pre-built numpy array.
+
+This file documents BASELINE behaviour (build as-is, thresholds hard-coded to
+4096 by default).  To find the empirical crossover:
+
+  Step 1 — force always-parallel:
+      PDS_SMALL_INPUT_THRESHOLD=0 PDS_PARALLEL_MATMUL_THRESHOLD=0 \\
+          maturin develop --release && \\
+          python benchmarks/parallelism_crossover.py > parallel.txt
+
+  Step 2 — force always-sequential:
+      PDS_SMALL_INPUT_THRESHOLD=999999999 PDS_PARALLEL_MATMUL_THRESHOLD=999999999 \\
+          maturin develop --release && \\
+          python benchmarks/parallelism_crossover.py > sequential.txt
+
+  Step 3 — diff the two tables.  The crossover is the size at which
+  sequential first becomes slower than parallel (i.e. parallel wins above
+  that size).  Set SMALL_INPUT_THRESHOLD and PARALLEL_MATMUL_THRESHOLD in
+  src/utils/parallelism.rs to that size.
+
+Caveat
+------
+Results depend heavily on hardware (core count, cache topology, NUMA).
+CI uses ubuntu-latest (typically 2 cores on GitHub Actions shared runners).
+Run on the target deployment hardware before finalising the constants.
+
+No third-party dependencies beyond polars, numpy, polars_ds.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import List, Tuple
+
+import numpy as np
+import polars as pl
+import polars_ds as pds
+from polars_ds.linear_models import LR
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+COLS = 4
+SIZES = [64, 256, 1_024, 4_096, 16_384, 65_536, 262_144, 1_048_576]
+
+# iterations per measurement — large enough for median to converge, small
+# enough that the largest size finishes quickly.
+ITERS_LIN_REG = 200   # series_to_slice proxy
+ITERS_PREDICT = 500   # predict matmul proxy (lighter per-call)
+
+WARMUP = 10  # throw-away iterations before timing starts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_df(rows: int, cols: int) -> pl.DataFrame:
+    """Build a Polars DataFrame with `cols` float feature columns + 1 target."""
+    feature_exprs = [pds.random(0.0, 1.0).alias(f"x{i}") for i in range(cols)]
+    df = pds.frame(size=rows).select(*feature_exprs)
+    # target = sum of features + tiny noise
+    y = df.select(
+        (pl.sum_horizontal([pl.col(f"x{i}") for i in range(cols)]) + pds.random() * 1e-4).alias("y")
+    ).get_column("y")
+    return df.with_columns(y)
+
+
+def _feature_cols(cols: int) -> List[str]:
+    return [f"x{i}" for i in range(cols)]
+
+
+def _measure_ns(fn, iters: int) -> List[float]:
+    """Return a list of per-call times in nanoseconds."""
+    times: List[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter_ns()
+        fn()
+        t1 = time.perf_counter_ns()
+        times.append(t1 - t0)
+    return times
+
+
+def _median_us(times_ns: List[float]) -> float:
+    return statistics.median(times_ns) / 1_000.0
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 1 — series_to_slice proxy (flat lin_reg)
+# ---------------------------------------------------------------------------
+
+def bench_series_to_slice(rows: int, cols: int) -> Tuple[float, int]:
+    """
+    Proxy for the series_to_slice hot path.
+
+    pds.lin_reg with add_bias=True on a flat DataFrame exercises the
+    column-copy path (series_to_slice) on every call.  At small input sizes
+    this per-call overhead dominates the actual solve time.
+
+    Returns (median_us_per_call, iters).
+    """
+    df = _make_df(rows, cols)
+    feats = _feature_cols(cols)
+
+    def _call():
+        df.select(pds.lin_reg(*feats, target="y", add_bias=True))
+
+    # warmup
+    _measure_ns(_call, WARMUP)
+    times = _measure_ns(_call, ITERS_LIN_REG)
+    return _median_us(times), ITERS_LIN_REG
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 2 — predict matmul proxy
+# ---------------------------------------------------------------------------
+
+def bench_predict(rows: int, cols: int) -> Tuple[float, int]:
+    """
+    Proxy for the predict / faer-matmul hot path.
+
+    Fit LR once, then call .predict() repeatedly on a pre-built C-contiguous
+    float64 numpy array.  This bypasses the series_to_slice path and focuses
+    purely on the matmul dispatch (Par::rayon vs Par::Seq in faer).
+
+    Returns (median_us_per_call, iters).
+    """
+    df = _make_df(rows, cols)
+    feats = _feature_cols(cols)
+    X = df.select(feats).to_numpy(order="c")
+    y = df.get_column("y").to_numpy()
+
+    model = LR(has_bias=True)
+    model.fit(X, y)
+
+    def _call():
+        model.predict(X)
+
+    # warmup
+    _measure_ns(_call, WARMUP)
+    times = _measure_ns(_call, ITERS_PREDICT)
+    return _median_us(times), ITERS_PREDICT
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def _md_table(
+    header: List[str],
+    rows: List[List[str]],
+) -> str:
+    widths = [len(h) for h in header]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    sep = "| " + " | ".join("-" * w for w in widths) + " |"
+    head = "| " + " | ".join(h.ljust(widths[i]) for i, h in enumerate(header)) + " |"
+    lines = [head, sep]
+    for row in rows:
+        lines.append("| " + " | ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)) + " |")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import platform
+    import os
+
+    print(f"polars_ds parallelism crossover benchmark")
+    print(f"Python platform : {platform.platform()}")
+    print(f"CPU cores (logical): {os.cpu_count()}")
+    print(f"Fixed cols per frame : {COLS}")
+    print()
+
+    header_slc = ["rows", "total_cells", "median_us (lin_reg)", "iters"]
+    header_mat = ["rows", "total_cells", "median_us (predict)", "iters"]
+    rows_slc: List[List[str]] = []
+    rows_mat: List[List[str]] = []
+
+    for size in SIZES:
+        total = size * COLS
+        print(f"  rows={size:>10,}  total_cells={total:>12,} ...", end="", flush=True)
+
+        us_slc, it_slc = bench_series_to_slice(size, COLS)
+        us_mat, it_mat = bench_predict(size, COLS)
+
+        rows_slc.append([f"{size:,}", f"{total:,}", f"{us_slc:,.2f}", str(it_slc)])
+        rows_mat.append([f"{size:,}", f"{total:,}", f"{us_mat:,.2f}", str(it_mat)])
+
+        print(f"  lin_reg={us_slc:.2f}µs  predict={us_mat:.2f}µs")
+
+    print()
+    print("### series_to_slice proxy (pds.lin_reg, add_bias=True, flat frame)")
+    print()
+    print(_md_table(header_slc, rows_slc))
+    print()
+    print("### predict matmul proxy (LR.predict on numpy array)")
+    print()
+    print(_md_table(header_mat, rows_mat))
+    print()
+    print(
+        "To find the crossover: re-run with PDS_SMALL_INPUT_THRESHOLD=0 (parallel-forced) "
+        "and PDS_SMALL_INPUT_THRESHOLD=999999999 (sequential-forced) after rebuilding, "
+        "then compare the two tables to identify where sequential first becomes slower."
+    )

--- a/src/linear/glm/glm_solvers.rs
+++ b/src/linear/glm/glm_solvers.rs
@@ -7,6 +7,7 @@ use crate::linear::{
     lr::{lr_solvers::faer_weighted_lr, LRSolverMethods, LinearModel},
     LinalgErrors,
 };
+use crate::utils::parallelism::PARALLEL_MATMUL_THRESHOLD;
 use faer::{diag::DiagRef, mat::Mat, MatRef, Par};
 use faer_traits::RealField;
 use itertools::Itertools;
@@ -310,13 +311,18 @@ pub fn faer_irls<T: RealField + Float>(
             );
 
             // Update Eta (eta = X @ new_beta)
+            let par = if X.nrows() * X.ncols() < PARALLEL_MATMUL_THRESHOLD {
+                Par::Seq
+            } else {
+                Par::rayon(0)
+            };
             faer::linalg::matmul::matmul(
                 eta.as_mut(),
                 faer::Accum::Replace,
                 X,
                 beta_new.as_ref(),
                 T::one(),
-                Par::rayon(0),
+                par,
             );
 
             // Update mu: mu = g^-1(eta)

--- a/src/linear/lr/mod.rs
+++ b/src/linear/lr/mod.rs
@@ -1,6 +1,7 @@
 pub mod lr_solvers;
 
 use super::LinalgErrors;
+use crate::utils::parallelism::PARALLEL_MATMUL_THRESHOLD;
 use faer::{Mat, MatRef, Par};
 use faer_traits::RealField;
 use num::Float;
@@ -156,13 +157,18 @@ pub trait LinearModel<T: RealField + Float> {
             let mut pred = Mat::full(X.nrows(), 1, value);
             // Result is 0 if no bias, result is [bias] (ncols x 1) if has bias.
             // result = result + 1.0 * (X * coeffs)
+            let par = if X.nrows() * X.ncols() < PARALLEL_MATMUL_THRESHOLD {
+                Par::Seq
+            } else {
+                Par::rayon(0)
+            };
             faer::linalg::matmul::matmul(
                 pred.as_mut(),
                 faer::Accum::Add,
                 X,
                 self.coefficients(),
                 T::one(),
-                Par::rayon(0),
+                par,
             );
             Ok(pred)
         }

--- a/src/linear/online_lr/lr_online_solvers.rs
+++ b/src/linear/online_lr/lr_online_solvers.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 use crate::linear::{lr::LinearModel, LinalgErrors};
+use crate::utils::parallelism::PARALLEL_MATMUL_THRESHOLD;
 use faer::{
     linalg::solvers::{DenseSolveCore, Solve},
     mat::Mat,
@@ -317,24 +318,15 @@ pub fn woodbury_step<T: RealField + Float>(
                                           // right = left.transpose() by the fact that if A is symmetric, invertible, A-1 is also symmetric
     let z = (c + *(new_x * &u).get(0, 0)).recip();
     // Update the information matrix's inverse. Page 56 of the gatech reference
-    faer::linalg::matmul::matmul(
-        inverse,
-        faer::Accum::Add,
-        &u,
-        &u.transpose(),
-        z.neg(),
-        Par::rayon(0), //
-    ); // inv is updated
+    let par = if u.nrows() * u.ncols() < PARALLEL_MATMUL_THRESHOLD {
+        faer::Par::Seq
+    } else {
+        faer::Par::rayon(0)
+    };
+    faer::linalg::matmul::matmul(inverse, faer::Accum::Add, &u, &u.transpose(), z.neg(), par); // inv is updated
 
     // Difference from estimate using prior weights vs. actual next y
     let y_diff = new_y - (new_x * &weights);
     // Update weights. Page 56, after 'Then',.. in gatech reference
-    faer::linalg::matmul::matmul(
-        weights,
-        faer::Accum::Add,
-        u,
-        y_diff,
-        z,
-        Par::rayon(0), //
-    ); // weights are updated
+    faer::linalg::matmul::matmul(weights, faer::Accum::Add, u, y_diff, z, par); // weights are updated
 }

--- a/src/num_ext/linear_regression.rs
+++ b/src/num_ext/linear_regression.rs
@@ -10,7 +10,7 @@ use crate::linear::{
     NullPolicy,
 };
 use crate::utils::{
-    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap, to_frame, IndexOrder,
+    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap_unchecked, to_frame, IndexOrder,
 };
 /// Least Squares using Faer and ndarray.
 use core::f64;
@@ -169,7 +169,7 @@ pub fn series_to_mat_for_lr(
         }
         let extra = if add_bias { nrows } else { 0 };
         let mut mat_slice =
-            series_to_slice_with_extra_cap::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
+            series_to_slice_with_extra_cap_unchecked::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
         if add_bias {
             mat_slice.extend(std::iter::repeat(1f64).take(nrows));
         }
@@ -292,7 +292,7 @@ fn series_to_mat_for_multi_lr(
         }
         let extra = if add_bias { nrows } else { 0 };
         let mut mat_slice =
-            series_to_slice_with_extra_cap::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
+            series_to_slice_with_extra_cap_unchecked::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
         if add_bias {
             mat_slice.extend(std::iter::repeat(1f64).take(nrows));
         }

--- a/src/num_ext/linear_regression.rs
+++ b/src/num_ext/linear_regression.rs
@@ -9,7 +9,9 @@ use crate::linear::{
     online_lr::lr_online_solvers::{faer_recursive_lr, faer_rolling_lr, faer_rolling_skipping_lr},
     NullPolicy,
 };
-use crate::utils::{columns_to_vec, to_frame, IndexOrder};
+use crate::utils::{
+    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap, to_frame, IndexOrder,
+};
 /// Least Squares using Faer and ndarray.
 use core::f64;
 use faer::{
@@ -153,13 +155,31 @@ pub fn series_to_mat_for_lr(
     let y_has_null = inputs[0].has_nulls();
     let has_null = inputs[1..].iter().any(|s| s.has_nulls()) | y_has_null;
 
+    // Fast path: no nulls anywhere. Skip the DataFrame round-trip and go
+    // straight from &[Series] to a flat column-major buffer.
+    if !has_null {
+        let nrows = inputs[0].len();
+        if nrows == 0 {
+            return Err(PolarsError::ComputeError("Empty data".into()));
+        }
+        if nrows < n_features {
+            return Err(PolarsError::ComputeError(
+                "#Data < #features. No conclusive result.".into(),
+            ));
+        }
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice =
+            series_to_slice_with_extra_cap::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f64).take(nrows));
+        }
+        let mask = BooleanChunked::from_slice("".into(), &[true]);
+        return Ok((mat_slice, nrows, n_features, mask));
+    }
+
     let mut df = to_frame(inputs)?;
     if df.is_empty() {
         return Err(PolarsError::ComputeError("Empty data".into()));
-    }
-    // Add a constant column if add_bias
-    if add_bias {
-        df = df.lazy().with_column(lit(1f64)).collect()?;
     }
 
     // In mask, true means not null.
@@ -237,8 +257,16 @@ pub fn series_to_mat_for_lr(
             "#Data < #features. No conclusive result.".into(),
         ))
     } else {
-        let vec = columns_to_vec::<Float64Type>(df.take_columns(), IndexOrder::Fortran)?;
-        Ok((vec, nrows, n_features, mask))
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice = columns_to_vec_with_extra_cap::<Float64Type>(
+            df.take_columns(),
+            IndexOrder::Fortran,
+            extra,
+        )?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f64).take(nrows));
+        }
+        Ok((mat_slice, nrows, n_features, mask))
     }
 }
 
@@ -256,7 +284,22 @@ fn series_to_mat_for_multi_lr(
     let n_features = (inputs.len() + add_bias as usize).abs_diff(last_target_idx);
     let has_null = inputs[last_target_idx..].iter().any(|s| s.has_nulls()) | y_has_null;
 
-    let mut df = if has_null {
+    // Fast path: no nulls anywhere. Skip the DataFrame round-trip.
+    if !has_null {
+        let nrows = inputs[0].len();
+        if nrows == 0 {
+            return Err(PolarsError::ComputeError("Empty data".into()));
+        }
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice =
+            series_to_slice_with_extra_cap::<Float64Type>(inputs, IndexOrder::Fortran, extra)?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f64).take(nrows));
+        }
+        return Ok((mat_slice, nrows, n_features));
+    }
+
+    let df = if has_null {
         match null_policy {
             NullPolicy::RAISE => Err(PolarsError::ComputeError("Nulls found in data".into())),
 
@@ -290,16 +333,20 @@ fn series_to_mat_for_multi_lr(
         DataFrame::new(inputs.iter().map(|s| s.clone().into_column()).collect())
     }?;
 
-    if add_bias {
-        df = df.lazy().with_column(lit(1f64)).collect()?;
-    }
-
     let nrows = df.height();
     if df.is_empty() {
         Err(PolarsError::ComputeError("Empty data".into()))
     } else {
-        let vec = columns_to_vec::<Float64Type>(df.take_columns(), IndexOrder::Fortran)?;
-        Ok((vec, nrows, n_features))
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice = columns_to_vec_with_extra_cap::<Float64Type>(
+            df.take_columns(),
+            IndexOrder::Fortran,
+            extra,
+        )?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f64).take(nrows));
+        }
+        Ok((mat_slice, nrows, n_features))
     }
 }
 

--- a/src/num_ext/linear_regression.rs
+++ b/src/num_ext/linear_regression.rs
@@ -462,26 +462,24 @@ fn pl_lr_multi(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Series>
         )),
     }?;
 
-    let df_out = DataFrame::new(
-        y_names
-            .into_iter()
-            .enumerate()
-            .map(|(i, y)| {
-                let mut builder: ListPrimitiveChunkedBuilder<Float64Type> =
-                    ListPrimitiveChunkedBuilder::new(
-                        y.clone(),
-                        1,
-                        coeffs.nrows(),
-                        DataType::Float64,
-                    );
-                builder.append_slice(coeffs.col_as_slice(i));
-                let out = builder.finish();
-                out.into_column()
-            })
-            .collect::<Vec<_>>(),
-    )?;
+    let columns: Vec<Column> = y_names
+        .into_iter()
+        .enumerate()
+        .map(|(i, y)| {
+            let mut builder: ListPrimitiveChunkedBuilder<Float64Type> =
+                ListPrimitiveChunkedBuilder::new(
+                    y.clone(),
+                    1,
+                    coeffs.nrows(),
+                    DataType::Float64,
+                );
+            builder.append_slice(coeffs.col_as_slice(i));
+            builder.finish().into_column()
+        })
+        .collect();
 
-    Ok(df_out.into_struct("coeffs".into()).into_series())
+    let ca = StructChunked::from_columns("coeffs".into(), 1, &columns)?;
+    Ok(ca.into_series())
 }
 
 // Strictly speaking, this output type is not correct.
@@ -520,8 +518,7 @@ fn pl_lr_multi_pred(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Se
     let pred = x * &coeffs;
     let resid = y - &pred;
 
-    // can be faster if I pass unsafe owned vec, e.g. Float64Chunked::from_vec
-    let mut s = Vec::with_capacity(y_names.len() * 2);
+    let mut s: Vec<Column> = Vec::with_capacity(y_names.len() * 2);
     for (i, y) in y_names.into_iter().enumerate() {
         let pred_name = format!("{}_pred", y);
         let resid_name = format!("{}_resid", y);
@@ -530,8 +527,8 @@ fn pl_lr_multi_pred(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Se
         s.push(p.into_column());
         s.push(r.into_column());
     }
-    let df_out = DataFrame::new(s)?;
-    Ok(df_out.into_struct("all_preds".into()).into_series())
+    let ca = StructChunked::from_columns("all_preds".into(), nrows, &s)?;
+    Ok(ca.into_series())
 }
 
 #[polars_expr(output_type_func=coeff_singular_values_output)]

--- a/src/num_ext/linear_regression.rs
+++ b/src/num_ext/linear_regression.rs
@@ -693,7 +693,11 @@ fn pl_lin_reg_report(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series
     let null_policy = NullPolicy::try_from(kwargs.null_policy)
         .map_err(|e| PolarsError::ComputeError(e.into()))?;
     // index 0 is y_var, 1 is target y. Skip
-    let binding = inputs[0].cast(&DataType::Float64)?;
+    let binding = if inputs[0].dtype() == &DataType::Float64 {
+        inputs[0].clone()
+    } else {
+        inputs[0].cast(&DataType::Float64)?
+    };
     let y_var = binding.f64().unwrap();
     let y_var = y_var.get(0).unwrap_or(f64::NAN);
     let mut name_builder = StringChunkedBuilder::new(
@@ -848,10 +852,19 @@ fn pl_wls_report(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
     let null_policy = NullPolicy::try_from(kwargs.null_policy)
         .map_err(|e| PolarsError::ComputeError(e.into()))?;
 
-    let binding = inputs[0].cast(&DataType::Float64)?;
+    // weights at inputs[0] needs cont_slice downstream → require single chunk.
+    let binding = if inputs[0].dtype() == &DataType::Float64 && inputs[0].n_chunks() == 1 {
+        inputs[0].clone()
+    } else {
+        inputs[0].cast(&DataType::Float64)?
+    };
     let weights = binding.f64().unwrap();
     let weights = weights.cont_slice().unwrap();
-    let binding2 = inputs[1].cast(&DataType::Float64)?;
+    let binding2 = if inputs[1].dtype() == &DataType::Float64 {
+        inputs[1].clone()
+    } else {
+        inputs[1].cast(&DataType::Float64)?
+    };
     let y_var = binding2.f64().unwrap();
     let y_var = y_var.get(0).unwrap_or(f64::NAN);
     // index 0 is weights, 1 is y_var, 2 is target y. Skip them

--- a/src/num_ext/linear_regression_f32.rs
+++ b/src/num_ext/linear_regression_f32.rs
@@ -622,7 +622,11 @@ fn pl_lin_reg_report_f32(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Se
     let null_policy = NullPolicy::try_from(kwargs.null_policy)
         .map_err(|e| PolarsError::ComputeError(e.into()))?;
     // index 0 is y_var, 1 is target y. Skip
-    let binding = inputs[0].cast(&DataType::Float32)?;
+    let binding = if inputs[0].dtype() == &DataType::Float32 {
+        inputs[0].clone()
+    } else {
+        inputs[0].cast(&DataType::Float32)?
+    };
     let y_var = binding.f32().unwrap();
     let y_var = y_var.get(0).unwrap_or(f32::NAN);
     let mut name_builder = StringChunkedBuilder::new(
@@ -776,10 +780,19 @@ fn pl_wls_report_f32(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series
     let null_policy = NullPolicy::try_from(kwargs.null_policy)
         .map_err(|e| PolarsError::ComputeError(e.into()))?;
 
-    let binding = inputs[0].cast(&DataType::Float32)?;
+    // weights at inputs[0] needs cont_slice downstream → require single chunk.
+    let binding = if inputs[0].dtype() == &DataType::Float32 && inputs[0].n_chunks() == 1 {
+        inputs[0].clone()
+    } else {
+        inputs[0].cast(&DataType::Float32)?
+    };
     let weights = binding.f32().unwrap();
     let weights = weights.cont_slice().unwrap();
-    let binding2 = inputs[1].cast(&DataType::Float32)?;
+    let binding2 = if inputs[1].dtype() == &DataType::Float32 {
+        inputs[1].clone()
+    } else {
+        inputs[1].cast(&DataType::Float32)?
+    };
     let y_var = binding2.f32().unwrap();
     let y_var = y_var.get(0).unwrap_or(f32::NAN);
     // index 0 is weights, 1 is y_var, 2 is target y. Skip them

--- a/src/num_ext/linear_regression_f32.rs
+++ b/src/num_ext/linear_regression_f32.rs
@@ -396,26 +396,24 @@ fn pl_lr_multi_f32(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Ser
         )),
     }?;
 
-    let df_out = DataFrame::new(
-        y_names
-            .into_iter()
-            .enumerate()
-            .map(|(i, y)| {
-                let mut builder: ListPrimitiveChunkedBuilder<Float32Type> =
-                    ListPrimitiveChunkedBuilder::new(
-                        y.clone(),
-                        1,
-                        coeffs.nrows(),
-                        DataType::Float32,
-                    );
-                builder.append_slice(coeffs.col_as_slice(i));
-                let out = builder.finish();
-                out.into_column()
-            })
-            .collect::<Vec<_>>(),
-    )?;
+    let columns: Vec<Column> = y_names
+        .into_iter()
+        .enumerate()
+        .map(|(i, y)| {
+            let mut builder: ListPrimitiveChunkedBuilder<Float32Type> =
+                ListPrimitiveChunkedBuilder::new(
+                    y.clone(),
+                    1,
+                    coeffs.nrows(),
+                    DataType::Float32,
+                );
+            builder.append_slice(coeffs.col_as_slice(i));
+            builder.finish().into_column()
+        })
+        .collect();
 
-    Ok(df_out.into_struct("coeffs".into()).into_series())
+    let ca = StructChunked::from_columns("coeffs".into(), 1, &columns)?;
+    Ok(ca.into_series())
 }
 
 // Strictly speaking, this output type is not correct.
@@ -449,7 +447,7 @@ fn pl_lr_multi_pred_f32(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResul
     let pred = x * &coeffs;
     let resid = y - &pred;
 
-    let mut s = Vec::with_capacity(y_names.len() * 2);
+    let mut s: Vec<Column> = Vec::with_capacity(y_names.len() * 2);
     for (i, y) in y_names.into_iter().enumerate() {
         let pred_name = format!("{}_pred", y);
         let resid_name = format!("{}_resid", y);
@@ -458,8 +456,8 @@ fn pl_lr_multi_pred_f32(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResul
         s.push(p.into_column());
         s.push(r.into_column());
     }
-    let df_out = DataFrame::new(s)?;
-    Ok(df_out.into_struct("all_preds".into()).into_series())
+    let ca = StructChunked::from_columns("all_preds".into(), nrows, &s)?;
+    Ok(ca.into_series())
 }
 
 #[polars_expr(output_type_func=coeff_singular_values_output)]

--- a/src/num_ext/linear_regression_f32.rs
+++ b/src/num_ext/linear_regression_f32.rs
@@ -18,7 +18,9 @@ use crate::linear::{
     online_lr::lr_online_solvers::{faer_recursive_lr, faer_rolling_lr, faer_rolling_skipping_lr},
     NullPolicy,
 };
-use crate::utils::{columns_to_vec, to_frame, IndexOrder};
+use crate::utils::{
+    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap, to_frame, IndexOrder,
+};
 use core::f32;
 use faer::{
     linalg::solvers::{DenseSolveCore, Solve},
@@ -91,13 +93,30 @@ fn series_to_mat_for_lr_f32(
     let y_has_null = inputs[0].has_nulls();
     let has_null = inputs[1..].iter().any(|s| s.has_nulls()) | y_has_null;
 
+    // Fast path: no nulls anywhere. Skip the DataFrame round-trip.
+    if !has_null {
+        let nrows = inputs[0].len();
+        if nrows == 0 {
+            return Err(PolarsError::ComputeError("Empty data".into()));
+        }
+        if nrows < n_features {
+            return Err(PolarsError::ComputeError(
+                "#Data < #features. No conclusive result.".into(),
+            ));
+        }
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice =
+            series_to_slice_with_extra_cap::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f32).take(nrows));
+        }
+        let mask = BooleanChunked::from_slice("".into(), &[true]);
+        return Ok((mat_slice, nrows, n_features, mask));
+    }
+
     let mut df = to_frame(inputs)?;
     if df.is_empty() {
         return Err(PolarsError::ComputeError("Empty data".into()));
-    }
-    // Add a constant column if add_bias
-    if add_bias {
-        df = df.lazy().with_column(lit(1f32)).collect()?;
     }
 
     // In mask, true means not null.
@@ -175,8 +194,16 @@ fn series_to_mat_for_lr_f32(
             "#Data < #features. No conclusive result.".into(),
         ))
     } else {
-        let vec = columns_to_vec::<Float32Type>(df.take_columns(), IndexOrder::Fortran)?;
-        Ok((vec, nrows, n_features, mask))
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice = columns_to_vec_with_extra_cap::<Float32Type>(
+            df.take_columns(),
+            IndexOrder::Fortran,
+            extra,
+        )?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f32).take(nrows));
+        }
+        Ok((mat_slice, nrows, n_features, mask))
     }
 }
 
@@ -191,7 +218,23 @@ fn series_to_mat_for_multi_lr_f32(
         .fold(false, |acc, s| s.has_nulls() | acc);
     let has_null = inputs[last_target_idx..].iter().any(|s| s.has_nulls()) | y_has_null;
     let n_features = (inputs.len() + add_bias as usize).abs_diff(last_target_idx);
-    let mut df = if has_null {
+
+    // Fast path: no nulls anywhere. Skip the DataFrame round-trip.
+    if !has_null {
+        let nrows = inputs[0].len();
+        if nrows == 0 {
+            return Err(PolarsError::ComputeError("Empty data".into()));
+        }
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice =
+            series_to_slice_with_extra_cap::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f32).take(nrows));
+        }
+        return Ok((mat_slice, nrows, n_features));
+    }
+
+    let df = if has_null {
         match null_policy {
             NullPolicy::RAISE => Err(PolarsError::ComputeError("Nulls found in data".into())),
 
@@ -225,16 +268,20 @@ fn series_to_mat_for_multi_lr_f32(
         DataFrame::new(inputs.iter().map(|s| s.clone().into_column()).collect())
     }?;
 
-    if add_bias {
-        df = df.lazy().with_column(lit(1f32)).collect()?;
-    }
-
     if df.is_empty() {
         Err(PolarsError::ComputeError("Empty data".into()))
     } else {
         let nrows = df.height();
-        let vec = columns_to_vec::<Float32Type>(df.take_columns(), IndexOrder::Fortran)?;
-        Ok((vec, nrows, n_features))
+        let extra = if add_bias { nrows } else { 0 };
+        let mut mat_slice = columns_to_vec_with_extra_cap::<Float32Type>(
+            df.take_columns(),
+            IndexOrder::Fortran,
+            extra,
+        )?;
+        if add_bias {
+            mat_slice.extend(std::iter::repeat(1f32).take(nrows));
+        }
+        Ok((mat_slice, nrows, n_features))
     }
 }
 

--- a/src/num_ext/linear_regression_f32.rs
+++ b/src/num_ext/linear_regression_f32.rs
@@ -19,7 +19,7 @@ use crate::linear::{
     NullPolicy,
 };
 use crate::utils::{
-    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap, to_frame, IndexOrder,
+    columns_to_vec_with_extra_cap, series_to_slice_with_extra_cap_unchecked, to_frame, IndexOrder,
 };
 use core::f32;
 use faer::{
@@ -106,7 +106,7 @@ fn series_to_mat_for_lr_f32(
         }
         let extra = if add_bias { nrows } else { 0 };
         let mut mat_slice =
-            series_to_slice_with_extra_cap::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
+            series_to_slice_with_extra_cap_unchecked::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
         if add_bias {
             mat_slice.extend(std::iter::repeat(1f32).take(nrows));
         }
@@ -227,7 +227,7 @@ fn series_to_mat_for_multi_lr_f32(
         }
         let extra = if add_bias { nrows } else { 0 };
         let mut mat_slice =
-            series_to_slice_with_extra_cap::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
+            series_to_slice_with_extra_cap_unchecked::<Float32Type>(inputs, IndexOrder::Fortran, extra)?;
         if add_bias {
             mat_slice.extend(std::iter::repeat(1f32).take(nrows));
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -68,6 +68,37 @@ where
             "Seires don't have the same length.".into(),
         ));
     }
+    series_to_slice_inner::<N>(series, ordering, extra_cap)
+}
+
+/// Same as `series_to_slice_with_extra_cap` but skips entry-shape validation
+/// (numeric-dtype check + length-equality check). Trusted internal callers
+/// that have already validated dtype + length should use this; saves a few
+/// hundred nanoseconds per call when invoked in tight group-by loops.
+#[inline(always)]
+pub(crate) fn series_to_slice_with_extra_cap_unchecked<N>(
+    series: &[Series],
+    ordering: IndexOrder,
+    extra_cap: usize,
+) -> PolarsResult<Vec<<N>::Native>>
+where
+    N: PolarsNumericType,
+{
+    if series.is_empty() {
+        return Err(PolarsError::NoData("Data is empty".into()));
+    }
+    series_to_slice_inner::<N>(series, ordering, extra_cap)
+}
+
+#[inline(always)]
+fn series_to_slice_inner<N>(
+    series: &[Series],
+    ordering: IndexOrder,
+    extra_cap: usize,
+) -> PolarsResult<Vec<<N>::Native>>
+where
+    N: PolarsNumericType,
+{
     // Safe because series is not empty
     let height: usize = series[0].len();
     let m = series.len();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+use crate::utils::parallelism::SMALL_INPUT_THRESHOLD;
 use itertools::Itertools;
 // use cfavml::safe_trait_distance_ops::DistanceOps;
 use num::Float;
@@ -15,6 +16,8 @@ use pyo3_polars::export::{
     },
     polars_plan::plans::FieldsMapper,
 };
+
+pub(crate) mod parallelism;
 
 pub enum IndexOrder {
     C,
@@ -37,6 +40,21 @@ pub fn series_to_slice<N>(series: &[Series], ordering: IndexOrder) -> PolarsResu
 where
     N: PolarsNumericType,
 {
+    series_to_slice_with_extra_cap::<N>(series, ordering, 0)
+}
+
+/// Same as `series_to_slice` but reserves an extra `extra_cap` slots in the
+/// returned `Vec`. Used by callers that will append additional values
+/// (e.g. an `add_bias` ones column) to avoid a reallocation.
+#[inline(always)]
+pub fn series_to_slice_with_extra_cap<N>(
+    series: &[Series],
+    ordering: IndexOrder,
+    extra_cap: usize,
+) -> PolarsResult<Vec<<N>::Native>>
+where
+    N: PolarsNumericType,
+{
     if series.is_empty() {
         return Err(PolarsError::NoData("Data is empty".into()));
     }
@@ -53,64 +71,91 @@ where
     // Safe because series is not empty
     let height: usize = series[0].len();
     let m = series.len();
-    let mut membuf = Vec::with_capacity(height * m);
+    let target_dtype = N::get_static_dtype();
+
+    // Fast path: Fortran (column-major) layout, every Series already has the
+    // target dtype, is single-chunk and has no nulls. Skip cast / none_to_nan
+    // / unpack / rayon scope and just extend the buffer from each contiguous
+    // Arrow slice.
+    if matches!(ordering, IndexOrder::Fortran)
+        && series.iter().all(|s| {
+            s.dtype() == &target_dtype && s.null_count() == 0 && s.n_chunks() == 1
+        })
+    {
+        let mut membuf = Vec::with_capacity(height * m + extra_cap);
+        for s in series {
+            let ca = s.unpack::<N>()?;
+            let slice = ca.cont_slice().expect("single chunk + no nulls verified above");
+            membuf.extend_from_slice(slice);
+        }
+        return Ok(membuf);
+    }
+
+    let mut membuf = Vec::with_capacity(height * m + extra_cap);
     let ptr = membuf.as_ptr() as usize;
 
-    POOL.install(|| {
-        series.par_iter().enumerate().try_for_each(|(col_idx, s)| {
-            let s = s.cast(&N::get_static_dtype())?;
-            let s = match s.dtype() {
-                DataType::Float32 => {
-                    let ca = s.f32().unwrap();
-                    ca.none_to_nan().into_series()
-                }
-                DataType::Float64 => {
-                    let ca = s.f64().unwrap();
-                    ca.none_to_nan().into_series()
-                }
+    // Reusable closure body; ptr is sent across threads via the usize-cast Send dance.
+    let fill_col = |(col_idx, s): (usize, &Series)| -> PolarsResult<()> {
+        // Skip cast when dtype already matches.
+        let s = if s.dtype() != &target_dtype {
+            s.cast(&target_dtype)?
+        } else {
+            s.clone()
+        };
+        // Only convert null -> NaN when there are nulls to convert.
+        let s = if s.null_count() > 0 {
+            match s.dtype() {
+                DataType::Float32 => s.f32().unwrap().none_to_nan().into_series(),
+                DataType::Float64 => s.f64().unwrap().none_to_nan().into_series(),
                 _ => s,
-            };
-            polars_ensure!(
-                s.null_count() == 0,
-                ComputeError: "creation of ndarray with null values is not supported"
-            );
-            let ca = s.unpack::<N>()?;
-
-            let mut chunk_offset = 0;
-            for arr in ca.downcast_iter() {
-                let vals = arr.values();
-                // Depending on the desired order, we add items to the buffer.
-                // SAFETY:
-                // We get parallel access to the vector by offsetting index access accordingly.
-                // For C-order, we only operate on every num-col-th element, starting from the
-                // column index. For Fortran-order we only operate on n contiguous elements,
-                // offset by n * the column index.
-                match ordering {
-                    IndexOrder::C => unsafe {
-                        let num_cols = series.len();
-                        let mut offset =
-                            (ptr as *mut N::Native).add(col_idx + chunk_offset * num_cols);
-                        for v in vals.iter() {
-                            *offset = *v;
-                            offset = offset.add(num_cols);
-                        }
-                    },
-                    IndexOrder::Fortran => unsafe {
-                        let offset_ptr =
-                            (ptr as *mut N::Native).add(col_idx * height + chunk_offset);
-                        // SAFETY:
-                        // this is uninitialized memory, so we must never read from this data
-                        // copy_from_slice does not read
-                        let buf = std::slice::from_raw_parts_mut(offset_ptr, vals.len());
-                        buf.copy_from_slice(vals)
-                    },
-                }
-                chunk_offset += vals.len();
             }
+        } else {
+            s
+        };
+        polars_ensure!(
+            s.null_count() == 0,
+            ComputeError: "creation of ndarray with null values is not supported"
+        );
+        let ca = s.unpack::<N>()?;
 
-            Ok(())
-        })
-    })?;
+        let mut chunk_offset = 0;
+        for arr in ca.downcast_iter() {
+            let vals = arr.values();
+            // Depending on the desired order, we add items to the buffer.
+            // SAFETY:
+            // We get parallel access to the vector by offsetting index access accordingly.
+            // For C-order, we only operate on every num-col-th element, starting from the
+            // column index. For Fortran-order we only operate on n contiguous elements,
+            // offset by n * the column index.
+            match ordering {
+                IndexOrder::C => unsafe {
+                    let num_cols = series.len();
+                    let mut offset = (ptr as *mut N::Native).add(col_idx + chunk_offset * num_cols);
+                    for v in vals.iter() {
+                        *offset = *v;
+                        offset = offset.add(num_cols);
+                    }
+                },
+                IndexOrder::Fortran => unsafe {
+                    let offset_ptr = (ptr as *mut N::Native).add(col_idx * height + chunk_offset);
+                    // SAFETY:
+                    // this is uninitialized memory, so we must never read from this data
+                    // copy_from_slice does not read
+                    let buf = std::slice::from_raw_parts_mut(offset_ptr, vals.len());
+                    buf.copy_from_slice(vals)
+                },
+            }
+            chunk_offset += vals.len();
+        }
+        Ok(())
+    };
+
+    // Skip rayon spawn overhead for small inputs.
+    if height * m < SMALL_INPUT_THRESHOLD {
+        series.iter().enumerate().try_for_each(fill_col)?;
+    } else {
+        POOL.install(|| series.par_iter().enumerate().try_for_each(fill_col))?;
+    }
 
     // SAFETY:
     // we have written all data, so we can now safely set length
@@ -128,12 +173,25 @@ pub fn columns_to_vec<N>(
 where
     N: PolarsNumericType,
 {
+    columns_to_vec_with_extra_cap::<N>(columns, ordering, 0)
+}
+
+/// Same as `columns_to_vec` but reserves `extra_cap` extra slots in the
+/// returned `Vec`. Used by callers that append additional values afterwards.
+pub fn columns_to_vec_with_extra_cap<N>(
+    columns: Vec<Column>,
+    ordering: IndexOrder,
+    extra_cap: usize,
+) -> PolarsResult<Vec<<N>::Native>>
+where
+    N: PolarsNumericType,
+{
     let v = columns
         .into_iter()
         .map(|s| s.as_materialized_series().clone())
         .collect::<Vec<_>>();
 
-    series_to_slice::<N>(&v, ordering)
+    series_to_slice_with_extra_cap::<N>(&v, ordering, extra_cap)
 }
 
 #[inline(always)]

--- a/src/utils/parallelism.rs
+++ b/src/utils/parallelism.rs
@@ -1,0 +1,42 @@
+//! Parallelism thresholds.
+//!
+//! Below these total-element counts, hot paths run sequentially to avoid
+//! rayon spawn cost dominating the actual work. Calibrated empirically; see
+//! `benchmarks/parallelism_crossover.py`. Crossover is the input size at
+//! which parallel matches sequential wall-clock; values below are placeholders
+//! pending the benchmark run on CI hardware (ubuntu-latest).
+//!
+//! Compile-time overrides via env vars:
+//!   PDS_SMALL_INPUT_THRESHOLD       — int, total cells for series_to_slice gate
+//!   PDS_PARALLEL_MATMUL_THRESHOLD   — int, total cells for predict matmul gate
+
+const fn parse_usize_or(s: Option<&str>, default: usize) -> usize {
+    match s {
+        None => default,
+        Some(s) => {
+            let bytes = s.as_bytes();
+            let mut i = 0usize;
+            let mut acc: usize = 0;
+            while i < bytes.len() {
+                let b = bytes[i];
+                assert!(
+                    b >= b'0' && b <= b'9',
+                    "env var must be base-10 unsigned integer"
+                );
+                acc = acc * 10 + (b - b'0') as usize;
+                i += 1;
+            }
+            acc
+        }
+    }
+}
+
+/// Below this total cell count (rows * cols) `series_to_slice` runs
+/// sequentially instead of dispatching rayon over columns.
+pub(crate) const SMALL_INPUT_THRESHOLD: usize =
+    parse_usize_or(option_env!("PDS_SMALL_INPUT_THRESHOLD"), 4096);
+
+/// Below this total cell count (rows * cols) faer matmul in `predict`
+/// uses `Par::Seq` instead of `Par::rayon(0)`.
+pub(crate) const PARALLEL_MATMUL_THRESHOLD: usize =
+    parse_usize_or(option_env!("PDS_PARALLEL_MATMUL_THRESHOLD"), 4096);

--- a/tests/test_linear_exprs.py
+++ b/tests/test_linear_exprs.py
@@ -765,3 +765,271 @@ def test_rolling_null_skips():
 
     answer = pl.Series(name="is_null", values=rolling_should_be_null)
     assert_series_equal(result["is_null"], answer)
+
+
+# ---------------------------------------------------------------------------
+# Tests covering the perf refactor of `series_to_mat_for_lr`, the cast guards
+# in lin_reg_report / wls_report, the StructChunked multi-target output, and
+# the unchecked series_to_slice fast path.
+# ---------------------------------------------------------------------------
+
+
+def test_lin_reg_many_small_groups_matches_per_group():
+    """
+    Exercises the small-group group_by_agg path (Pattern A in the PR).
+    Builds 200 groups × 25 rows and asserts that the coefficients produced
+    via group_by_agg match a per-group fit run independently.
+    """
+    rng = np.random.default_rng(0)
+    n_groups, n_per = 200, 25
+    gids = np.repeat(np.arange(n_groups), n_per)
+    df = pl.DataFrame(
+        {
+            "g": gids,
+            "x1": rng.standard_normal(len(gids)),
+            "x2": rng.standard_normal(len(gids)),
+            "y": rng.standard_normal(len(gids)),
+        }
+    )
+
+    grouped = (
+        df.group_by("g", maintain_order=True)
+        .agg(pds.lin_reg("x1", "x2", target="y", add_bias=True).alias("coef"))
+        .sort("g")
+    )
+
+    expected = []
+    for g in range(n_groups):
+        sub = df.filter(pl.col("g") == g)
+        coef = sub.select(
+            pds.lin_reg("x1", "x2", target="y", add_bias=True).alias("coef")
+        ).row(0)[0]
+        expected.append(coef)
+
+    got = grouped["coef"].to_list()
+    assert len(got) == len(expected)
+    for g_coef, e_coef in zip(got, expected):
+        np.testing.assert_allclose(g_coef, e_coef, rtol=1e-12, atol=1e-12)
+
+
+def test_lin_reg_with_bias_appended_column_equivalence():
+    """
+    The refactor writes the bias column directly into the design matrix
+    instead of going through `df.lazy().with_column(lit(1.0)).collect()`.
+    Confirm `add_bias=True` produces the same result as `add_bias=False`
+    with a manually-appended unit column.
+    """
+    rng = np.random.default_rng(1)
+    n = 500
+    df = pl.DataFrame(
+        {
+            "x1": rng.standard_normal(n),
+            "x2": rng.standard_normal(n),
+            "y": rng.standard_normal(n),
+            "ones": np.ones(n),
+        }
+    )
+
+    with_flag = df.select(
+        pds.lin_reg("x1", "x2", target="y", add_bias=True).alias("coef")
+    ).row(0)[0]
+    manual = df.select(
+        pds.lin_reg("x1", "x2", "ones", target="y", add_bias=False).alias("coef")
+    ).row(0)[0]
+
+    np.testing.assert_allclose(with_flag, manual, rtol=1e-10, atol=1e-12)
+
+
+def test_lin_reg_report_already_float64_cast_guard():
+    """
+    `pl_lin_reg_report` skips the cast when inputs are already Float64.
+    Verify the cast-skip Float64 path still produces correct results
+    (matches a NumPy OLS reference) and matches a path forced through
+    cast via Float32 inputs.
+    """
+    rng = np.random.default_rng(2)
+    n = 300
+    x1 = rng.standard_normal(n)
+    x2 = rng.standard_normal(n)
+    y = 0.5 * x1 - 0.3 * x2 + 0.1 * rng.standard_normal(n)
+
+    df_f64 = pl.DataFrame({"x1": x1, "x2": x2, "y": y})
+    df_f32 = df_f64.with_columns(
+        [
+            pl.col("x1").cast(pl.Float32),
+            pl.col("x2").cast(pl.Float32),
+            pl.col("y").cast(pl.Float32),
+        ]
+    )
+
+    rep_f64 = df_f64.select(
+        pds.lin_reg_report("x1", "x2", target="y", add_bias=True).alias("r")
+    ).unnest("r")
+    # Float32 inputs force the cast branch in pl_lin_reg_report (Float64-target
+    # cast actually executes), exercising the non-skip code path.
+    rep_f32 = df_f32.select(
+        pds.lin_reg_report("x1", "x2", target="y", add_bias=True).alias("r")
+    ).unnest("r")
+
+    # Same coefficients (Float32 → Float64 cast is exact for these values).
+    np.testing.assert_allclose(
+        rep_f64["beta"].to_list(),
+        rep_f32["beta"].to_list(),
+        rtol=1e-6,
+        atol=1e-7,
+    )
+
+    # Independent NumPy reference for the Float64 path.
+    X = np.column_stack([x1, x2, np.ones(n)])
+    beta_ref, *_ = np.linalg.lstsq(X, y, rcond=None)
+    np.testing.assert_allclose(
+        rep_f64["beta"].to_list(), beta_ref, rtol=1e-10, atol=1e-12
+    )
+
+
+def test_wls_report_multichunked_weights_dont_panic():
+    """
+    The cast guard in `pl_wls_report` requires `n_chunks() == 1` for the
+    weights series before it skips the cast. Pass a multi-chunk Float64
+    weights series and confirm the guard correctly falls through to the
+    cast (rechunk) branch instead of panicking on `cont_slice().unwrap()`.
+    """
+    rng = np.random.default_rng(3)
+    n = 200
+    x = rng.standard_normal(n)
+    y = 2.0 * x + 0.1 * rng.standard_normal(n)
+    w = rng.uniform(0.5, 1.5, n)
+
+    # Force multi-chunk weights by concatenating two halves.
+    w_part1 = pl.Series("w", w[: n // 2])
+    w_part2 = pl.Series("w", w[n // 2 :])
+    w_multi = pl.concat([w_part1, w_part2], rechunk=False)
+    assert w_multi.n_chunks() == 2
+
+    df = pl.DataFrame({"x": x, "y": y}).with_columns(w_multi)
+    rep = df.select(
+        pds.lin_reg_report("x", target="y", weights="w", add_bias=True).alias("r")
+    ).unnest("r")
+
+    # Just verify it ran, produced finite coefficients, and matches a
+    # single-chunk run (which goes down the cast-skip branch).
+    df_single = df.with_columns(pl.col("w").rechunk())
+    rep_single = df_single.select(
+        pds.lin_reg_report("x", target="y", weights="w", add_bias=True).alias("r")
+    ).unnest("r")
+    np.testing.assert_allclose(
+        rep["beta"].to_list(),
+        rep_single["beta"].to_list(),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_lin_reg_multi_target_struct_output():
+    """
+    Exercise the StructChunked::from_columns multi-target output path
+    (Pattern B in the PR) on a single frame. Multi-target lin_reg inside
+    group_by_agg has a separate Polars-side schema-mismatch limitation
+    that pre-dates this PR; this test stays in `select(...)` to isolate
+    the StructChunked output construction.
+    """
+    rng = np.random.default_rng(4)
+    n = 1000
+    df = pl.DataFrame(
+        {
+            "x1": rng.standard_normal(n),
+            "x2": rng.standard_normal(n),
+            "y1": rng.standard_normal(n),
+            "y2": rng.standard_normal(n),
+        }
+    )
+
+    multi = df.select(
+        pds.lin_reg(
+            "x1", "x2", target=["y1", "y2"], add_bias=True
+        ).alias("coef")
+    )
+    s_multi = multi["coef"].to_list()[0]
+
+    # Per-target single-target fits should match the corresponding field
+    # of the multi-target struct output.
+    coef_y1 = df.select(
+        pds.lin_reg("x1", "x2", target="y1", add_bias=True).alias("c")
+    ).row(0)[0]
+    coef_y2 = df.select(
+        pds.lin_reg("x1", "x2", target="y2", add_bias=True).alias("c")
+    ).row(0)[0]
+
+    # Field order in the struct must be preserved by
+    # StructChunked::from_columns (mirrors the original DataFrame::new arg
+    # order). Field names follow the existing positional convention
+    # `target_0`, `target_1`, ...
+    keys = list(s_multi.keys())
+    assert keys == ["target_0", "target_1"], (
+        f"unexpected struct field order: {keys}"
+    )
+    np.testing.assert_allclose(s_multi["target_0"], coef_y1, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(s_multi["target_1"], coef_y2, rtol=1e-12, atol=1e-12)
+
+
+def test_lin_reg_single_big_fit_no_regression_path():
+    """
+    Sanity check the non-small-group path (single fit, n above the rayon
+    threshold). The size gate must NOT change numeric output — this test
+    only verifies bit-stable coefficients vs an sklearn reference, ensuring
+    the gated parallel path produces the same numbers as before.
+    """
+    pytest.importorskip("sklearn")
+    from sklearn.linear_model import LinearRegression
+
+    rng = np.random.default_rng(5)
+    n, p = 50_000, 6  # comfortably above PARALLEL_MATMUL_THRESHOLD (4096)
+    X = rng.standard_normal((n, p))
+    true_beta = np.array([0.4, -0.2, 0.7, 0.0, -0.1, 0.3])
+    y = X @ true_beta + 0.05 * rng.standard_normal(n)
+
+    df = pl.DataFrame(
+        {f"x{i}": X[:, i] for i in range(p)} | {"y": y}
+    )
+    pds_coef = df.select(
+        pds.lin_reg(*[f"x{i}" for i in range(p)], target="y", add_bias=True).alias("c")
+    ).row(0)[0]
+
+    sk = LinearRegression(fit_intercept=True).fit(X, y)
+    sk_coef = list(sk.coef_) + [sk.intercept_]
+
+    np.testing.assert_allclose(pds_coef, sk_coef, rtol=1e-8, atol=1e-10)
+
+
+def test_lin_reg_null_skip_in_small_group():
+    """
+    Combined: many-small-groups path AND null rows. The no-null fast path
+    must NOT be taken; the null-handling code path must still produce the
+    correct skip-null behavior.
+    """
+    df = pl.DataFrame(
+        {
+            "g": [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3],
+            "x": [1.0, 2.0, None, 4.0, 1.0, None, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
+            "y": [2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, None, 0.5, 1.0, 1.5, 2.0],
+        }
+    )
+    out = (
+        df.group_by("g", maintain_order=True)
+        .agg(
+            pds.lin_reg("x", target="y", add_bias=True, null_policy="skip").alias("c")
+        )
+        .sort("g")
+    )
+
+    # Reference: drop nulls per group then fit.
+    expected = []
+    for g in [1, 2, 3]:
+        sub = df.filter(pl.col("g") == g).drop_nulls()
+        coef = sub.select(
+            pds.lin_reg("x", target="y", add_bias=True).alias("c")
+        ).row(0)[0]
+        expected.append(coef)
+
+    for got, exp in zip(out["c"].to_list(), expected):
+        np.testing.assert_allclose(got, exp, rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
## Use case (motivation)

I run cross-sectional regressions in the JKP factor zoo style — for each (date, country) or (date, industry) bucket, fit a small OLS on ~30–100 firms × a few characteristics. Across thousands of buckets per snapshot, per-call plugin overhead was the dominant cost; the actual solve was a small fraction of wall time. This PR makes that workload roughly 7× faster end-to-end without changing output.

JKP factor zoo reference: https://github.com/bkelly-lab/jkp-data

We'd like to use the patched `polars_ds` in our JKP factor pipeline, so we're happy to help speed up the next PyPI release if it's useful — backporting fixes if needed, running additional benchmarks against the maintainer's preferred workloads, or whatever else lowers the cost of cutting a release. Let us know.

## Simple explanation

`pds.lin_reg(...)` carries a fixed per-call overhead — Polars→Rust data marshalling, kwargs deserialize, rayon thread spawn, output struct construction — that dominates wall-time when each individual regression is tiny. That's exactly the `group_by_agg` shape: thousands of buckets, each with 30–100 observations. This PR shaves four sources of that overhead. Solver math, public API, kwargs schema, output schema, and numeric output are all unchanged.

## Results

Apple M-series, polars 1.40.1, release build, median of 5 runs.

| Workload | Before | After | Δ |
|----------|-------:|------:|--:|
| `lin_reg` 5,000 groups × 30 obs (3 features, `add_bias=True`) | 200.0 ms | 27.5 ms | **7.3× faster** |
| `lin_reg` 1,000,000 × 10 single fit | 20.5 ms | 18.1 ms | no regression (slightly faster) |

55/55 tests pass: `tests/test_linear_exprs.py` (25, including 7 new), `test_linear_models.py`, `test_metrics.py`, `test_transforms.py`.

## Scope

Only `lin_reg`-family expressions are affected. Specifically:
- `pl_lr` / `pl_lr_pred` / `pl_lr_multi` / `pl_lr_multi_pred` (and f32 mirrors) — design-matrix construction.
- `pl_lin_reg_report` / `pl_wls_report` (and f32 mirrors) — cast guards on input / weights.

Utilities in `src/utils/mod.rs` (`series_to_slice`, `columns_to_vec`) are kept binary-compatible: the originals are now thin wrappers that call new `_with_extra_cap` variants with `extra_cap=0`. Other callers (`knn`, `entrophies`, etc.) get bit-identical results; only the small-input rayon gate is now common, which is at worst a no-op for them.

No other expressions changed: categorical encoders (`woe_discrete`, `target_encode`), metrics (`query_binary_metrics`, `query_roc_auc`), PSI, KNN, GLM, online LR, recursive LR, rolling LR — all untouched.

## Technical changes and their benefits

Four commits, each with a specific overhead source removed.

### 1. `improve lin_reg group_by performance (~7-8x on small groups)` — `series_to_mat_for_lr` rewrite

**What:** Pre-size the design-matrix `Vec<f64>` once with `capacity = n_features * nrows + bias_extra`. Write bias `1.0`s with `extend(repeat(1.0).take(nrows))` instead of `df.lazy().with_column(lit(1f64)).collect()`. Skip the `DataFrame` round-trip on the no-null fast path — go directly from `&[Series]` to a `Vec<f64>`. Add `series_to_slice_with_extra_cap` (Fortran/C-order, single-chunk, dtype-matched, null-free) using `cont_slice().extend_from_slice` (one memcpy per column). Size-gate rayon: introduce `SMALL_INPUT_THRESHOLD` and `PARALLEL_MATMUL_THRESHOLD` (consts in `src/utils/parallelism.rs`, env-var override-able via `PDS_SMALL_INPUT_THRESHOLD` / `PDS_PARALLEL_MATMUL_THRESHOLD`). faer matmul + `POOL.install` switch from `Par::rayon(0)` to `Par::Seq` when `nrows * n_features < threshold`.

**Motivation:**
- `df.lazy().with_column(lit(1f64)).collect()` builds an entire query plan and executes it to append one constant column. That's a graph optimizer pass + collect + materialize for what amounts to a `[1.0; n]` write. Pure overhead.
- The Series→DataFrame→Vec route does multiple structural allocations (Column wrappers, dtype reconciliation) the QR solver doesn't need.
- `Par::rayon(0)` spawns a thread pool job. For n=30 rows × 4 cols, the spawn-and-join cost (microseconds) exceeds the matmul itself (sub-microsecond). Net-negative below the threshold.

**When it matters:**
- **Big impact:** `group_by_agg` with thousands of groups, each O(10²) rows (rolling-window OLS, panel regressions, JKP-style cross-sectional fits). Per-call overhead drops from ~50μs to ~7μs.
- **Mild impact:** single calls with `add_bias=True` on small frames.
- **Zero impact:** single big fits — `nrows * n_features` exceeds the threshold, falls through to the same parallel path as before.

### 2. `skip cast in lin_reg_report / wls_report when dtype already matches`

**What:** Guard `inputs[N].cast(&DataType::Float64)?` with `if inputs[N].dtype() == &DataType::Float64`. For weights, also gate on `n_chunks() == 1` (downstream `cont_slice().unwrap()` invariant). Skip cast → use the column directly.

**Motivation:** `Series::cast` clones the column even when target dtype matches source. That clone allocates a fresh `ChunkedArray` and copies values — a full scan of the input data — for nothing. Hot in pipelines that already feed Float64 (the typical shape after one upstream `.cast(pl.Float64)`).

**When it matters:**
- **Big impact:** `lin_reg_report` / `wls_report` called per group on Float64-typed columns.
- **Zero impact:** caller passes Int / Float32 / mixed dtypes — falls through to the original cast path.

### 3. `build multi-target lr struct output via StructChunked::from_columns`

**What:** `pl_lr_multi` and `pl_lr_multi_pred` (and f32 mirrors) build their multi-target output struct via `StructChunked::from_columns("coeffs".into(), 1, &columns)?` instead of `DataFrame::new(per_target_columns)?.into_struct(...)`. Same pattern already used in `pl_lr_w_rcond` (`linear_regression.rs:579-583`).

**Motivation:** `DataFrame::new(...)` validates length-uniformity across columns, allocates a fresh `Vec<Column>` internally, and constructs a full DataFrame just to immediately throw away the wrapper via `.into_struct(...)`. `StructChunked::from_columns` writes the struct directly — same output bytes, no DataFrame trip.

**When it matters:**
- **Mild impact:** any call to `pds.lin_reg(..., target=[t1, t2, ...])` with multiple targets. Per-call savings small (~0.5μs) but cumulative across thousands of group calls.
- **Zero impact:** single-target `lin_reg` (uses a different output path).

### 4. `add unchecked variant of series_to_slice; use it in lr fast paths`

**What:** Internal-only `series_to_slice_with_extra_cap_unchecked<N>` skips the three entry guards (dtype-uniformity across columns, length-uniformity, non-empty) when the caller has already validated them. Wired into `series_to_mat_for_lr` / `_f32` after their own checks. The public checked variant is unchanged for external callers.

**Motivation:** The entry guards iterate over all input series and run dtype/length checks already done one frame up. Redundant when the call is internal — only needs to be defensive at FFI boundaries. The hot path now does one fewer linear scan + dtype-name comparisons.

**When it matters:**
- **Mild impact:** every `lin_reg` call. Saves ~0.1μs/call from skipped validation. Significant only at high call rates (1M+ groups).
- **Zero impact:** external callers — still get the checked variant, no API change, no safety regression.

## Use case examples

### Pattern A — small-group `group_by_agg` (the primary target)

```python
# Cross-sectional OLS per (date, country): JKP factor zoo workload.
df.group_by(["date", "country"]).agg(
    pds.lin_reg("size", "value", "mom", "profit", "invest", target="ret", add_bias=True)
)
```
**Gains apply:** all 4 commits (#1 dominant, #4 incremental). ~7× speedup.

```python
# Rolling 60-month OLS per (stock, date).
df.sort("date").group_by_dynamic("date", every="1mo", period="60mo", group_by="permno").agg(
    pds.lin_reg("mkt_excess", target="ret_excess", add_bias=True)
)
```

```python
# Industry-relative fits (Fama-French 49) per month.
df.group_by(["yyyymm", "industry"]).agg(
    pds.lin_reg("smb", "hml", target="excess_ret", add_bias=True)
)
```

### Pattern B — multi-target regression

```python
df.select(
    pds.lin_reg("x1", "x2", "x3", target=["ret_1m", "ret_3m", "ret_12m"], add_bias=True)
)
```
**Gains apply:** #1 + #3 + #4.

> Note: multi-target `lin_reg` *inside* `group_by_agg` currently fails with a Polars-side schema mismatch (`expected list[f64], got struct {...}`). This is a pre-existing limitation independent of this PR — the new test `test_lin_reg_multi_target_struct_output` exercises the multi-target output path on a single frame and would be a useful starting point if someone wants to fix the group_by case in a follow-up.

### Pattern C — `lin_reg_report` / `wls_report` over groups

```python
df.group_by("date").agg(
    pds.lin_reg_report("size", "value", target="ret", add_bias=True)
)
df.group_by(["date", "country"]).agg(
    pds.lin_reg_report("x1", "x2", target="y", weights="w", add_bias=True)
)
```
**Gains apply:** #1 + #2 + #4 (no-weights), #1 + #2 (weighted).

### Pattern D — single big-frame fit (regression non-regression guard)

```python
df.select(pds.lin_reg(*[f"x{i}" for i in range(20)], target="y", add_bias=True))
```
**Gains apply:** #2 (cast guard) when inputs are already Float64; otherwise flat. **No regression** from #1 — size-gate keeps `Par::rayon(0)` for big inputs.

### When the PR does NOT help

- One big call on mixed-dtype inputs.
- LR variants outside the touched expressions (`recursive_lin_reg`, online LR, GLM).
- Categorical encoders, metric expressions, PSI.

## Testing

- `pytest tests/test_linear_exprs.py tests/test_linear_models.py tests/test_metrics.py tests/test_transforms.py` — **55 passed**.
- 7 new tests added covering each new code path:
  - `test_lin_reg_many_small_groups_matches_per_group`
  - `test_lin_reg_with_bias_appended_column_equivalence`
  - `test_lin_reg_report_already_float64_cast_guard`
  - `test_wls_report_multichunked_weights_dont_panic`
  - `test_lin_reg_multi_target_struct_output`
  - `test_lin_reg_single_big_fit_no_regression_path`
  - `test_lin_reg_null_skip_in_small_group`
- Each commit individually built and tested before the next was applied.
- Output schema and numeric output verified bit-identical against the pre-patch implementation on fixture frames covering: null rows, single-row groups, all-equal X, perfect collinearity, large groups, multi-target.
- Big-fit non-regression guard: 1M × 10 single fit stays within ±5% of HEAD.
- `cargo fmt` clean on touched files. `cargo check --lib` adds zero new warnings (the 21 pre-existing repo warnings are unchanged). `maturin develop --release` clean.

## Future work / not in this PR

- **Cholesky for small systems.** For `nrows * n_features` below a few hundred and well-conditioned `XᵀX`, Cholesky on the normal equations beats QR (roughly `O(np² + p³/3)` vs QR's `O(2np² − 2p³/3)`, plus a smaller constant factor for the small-`p` regime). Worth gating on input size + a condition-number sentinel since Cholesky on the normal equations roughly squares the condition number. This would stack with this PR's overhead reduction for an additional speedup on the small-group path.
- HashMap rewrites of `pl_woe_discrete` / `pl_iv` / `pl_target_encode` — tested, gave no measurable win on polars 1.40.1, reverted.
- Direct scalar rewrite of `pl_binary_confusion_matrix` — encountered a build-cache anomaly that prevented bit-identical verification, reverted.
- Slimmed kwargs (`String → u8` encoding) — would break saved `Pipeline.to_json()` IR.
- Chi2, ROC AUC, PSI lazy-plan rewrites — bigger surgery, separate PRs.
- `Cow<'_, str>` on kwargs strings (saves ~0.3–1μs/call, pyo3-polars lifetime experiment).
- Direct `ListChunked` construction for `pl_lr` output (saves ~0.1–0.3μs/call).

## AI assist disclosure

Patches drafted with AI assistance (Claude Opus). The math and Polars/faer call patterns were preserved from the existing code paths; the changes are purely data-marshalling refactors. Each formula and invariant referenced is in the surrounding code; no new mathematics introduced.