### PR TITLE
fix: usize underflow in isotonic_regression and lcs_substr (debug builds)

### DIFF
--- a/src/num_ext/isotonic_regression.rs
+++ b/src/num_ext/isotonic_regression.rs
@@ -7,9 +7,6 @@ use serde::Deserialize;
 // https://github.com/scipy/scipy/blob/v1.14.1/scipy/optimize/_pava/pava_pybind.cpp
 // https://www.jstatsoft.org/article/view/v102c01
 
-// The code here has to be compiled in --release
-// Otherwise, a mysterious error will occur. Thank you compiler!
-
 #[derive(Deserialize, Debug)]
 pub(crate) struct IsotonicRegKwargs {
     pub(crate) has_weights: bool,
@@ -65,6 +62,10 @@ fn isotonic_regression(x: &mut [f64], w: &mut [f64], r: &mut [usize]) {
         let xk = x[k];
         for i in t..=f {
             x[i] = xk;
+        }
+        // Avoid usize underflow on the final iteration when t == 0; f is unused after the loop.
+        if k == 0 {
+            break;
         }
         f = t - 1;
     }

--- a/src/str_ext/lcs_str.rs
+++ b/src/str_ext/lcs_str.rs
@@ -83,10 +83,8 @@ pub fn lcs_substr_extract(s1: &str, s2: &str) -> String {
         return String::new();
     }
 
-    // Extract the longest common substring from `longer_chars`
-    // using the calculated `max_len` and `end_index_in_longer_chars`.
-    // The starting index is derived by subtracting `max_len` and adding 1.
-    let start_index_in_longer_chars = end_index_in_longer_chars - max_len + 1;
+    // Reorder + before - to avoid usize underflow in debug builds when the substring starts at index 0.
+    let start_index_in_longer_chars = end_index_in_longer_chars + 1 - max_len;
     longer_chars[start_index_in_longer_chars..=end_index_in_longer_chars]
         .iter()
         .collect::<String>()


### PR DESCRIPTION
## Summary

Two pre-existing latent bugs that only manifest in debug builds (release builds disable overflow checks, so neither was visible to users running `maturin develop --release`).

- **`src/num_ext/isotonic_regression.rs`** — the back-fill loop's `f = t - 1` underflows in `usize` when `t == 0` on the final iteration. Guard with `if k == 0 { break; }` (`f` is unused after the loop). Removed the stale `// has to be compiled in --release / mysterious error` comment that documented the workaround.
- **`src/str_ext/lcs_str.rs`** — `end_index - max_len + 1` underflows in `usize` when the substring starts at index 0 (i.e. `max_len == end_index + 1`). Reorder to `end_index + 1 - max_len` to keep the intermediate value non-negative.

No algorithmic changes. Public API and numeric output unchanged.

This is one of several small focused PRs split out from #448 per @abstractqqq's request.

## Test plan

- [x] `cargo check --lib` clean (no new warnings)
- [x] Debug-build `maturin develop` succeeds
- [x] `pytest tests/test_many.py::test_isotonic` passes (previously panicked in debug)
- [x] `pytest tests/test_string.py::test_lcs_substr` passes