### PR TITLE
fix: null-safe variant of query_radius_ptwise (bug-029)

### DIFF
--- a/python/polars_ds/exprs/expr_knn.py
+++ b/python/polars_ds/exprs/expr_knn.py
@@ -16,6 +16,7 @@ __all__ = [
     "query_knn_freq_cnt",
     "query_knn_avg",
     "query_radius_ptwise",
+    "query_radius_ptwise_null_safe",
     "query_radius_freq_cnt",
     "query_nb_cnt",
     "query_dist_from_kth_nb",
@@ -521,6 +522,44 @@ def query_radius_ptwise(
         symbol="pl_query_radius_ptwise",
         args=cols,
         kwargs={"r": r, "metric": metric, "parallel": parallel, "sort": sort},
+    )
+
+
+def query_radius_ptwise_null_safe(
+    *features: str | pl.Expr,
+    index: str | pl.Expr,
+    r: float,
+    dist: Distance = "sql2",
+    sort: bool = True,
+    parallel: bool = False,
+) -> pl.Expr:
+    """
+    Null-safe variant of `query_radius_ptwise`. Rows where any feature column is null are
+    excluded from the kd-tree (they cannot be neighbors) and return null in the output list.
+
+    The non-null-safe `query_radius_ptwise` panics on null feature inputs because the kd-tree
+    builder reads features unchecked; use this variant when nulls cannot be ruled out upstream.
+
+    Parameters mirror `query_radius_ptwise`.
+    """
+    if r <= 0.0:
+        raise ValueError("Input `r` must be > 0.")
+    elif isinstance(r, pl.Expr):
+        raise ValueError("Input `r` must be a scalar now. Expression input is not implemented.")
+
+    if dist in ("cosine", "h", "haversine"):
+        raise ValueError(f"Distance {dist} doesn't work with current implementation.")
+
+    idx = to_expr(index).cast(pl.UInt32).rechunk()
+    feats = [to_expr(e) for e in features]
+    keep_mask = pl.all_horizontal(f.is_not_null() for f in feats)
+
+    cols = [idx, keep_mask]
+    cols.extend(feats)
+    return pl_plugin(
+        symbol="pl_query_radius_ptwise_null_safe",
+        args=cols,
+        kwargs={"r": r, "metric": str(dist).lower(), "parallel": parallel, "sort": sort},
     )
 
 

--- a/src/num_ext/knn.rs
+++ b/src/num_ext/knn.rs
@@ -580,6 +580,102 @@ fn pl_query_radius_ptwise(
     }
 }
 
+/// Null-safe variant of `query_radius_ptwise`.
+///
+/// Rows where any feature column is null are excluded from the kd-tree
+/// (they can never be neighbors) and return null in the output list.
+pub fn query_radius_ptwise_null_safe<'a, M: Metric>(
+    tree: &KDT<'a, u32, M>,
+    keep_mask: &BooleanChunked,
+    data: &'a [f64],
+    r: f64,
+    can_parallel: bool,
+    sort: bool,
+) -> ListChunked
+where
+    M: std::marker::Sync,
+{
+    let ncols = tree.dim;
+    let nrows = data.len() / ncols;
+    if can_parallel {
+        let n_threads = POOL.current_num_threads();
+        let splits = split_offsets(nrows, n_threads);
+        let mask_vec: Vec<bool> = keep_mask.iter().map(|b| b.unwrap_or(false)).collect();
+        let chunks_iter = splits.into_par_iter().map(|(offset, len)| {
+            let mut builder = ListPrimitiveChunkedBuilder::<UInt32Type>::new(
+                "".into(),
+                len,
+                16,
+                DataType::UInt32,
+            );
+            let subslice = &data[offset * ncols..(offset + len) * ncols];
+            let mask = &mask_vec[offset..offset + len];
+            for (b, p) in mask.iter().zip(subslice.chunks_exact(ncols)) {
+                if *b {
+                    if let Some(v) = tree.within(p, r, sort) {
+                        builder.append_values_iter(v.into_iter().map(|nb| nb.to_item()));
+                    } else {
+                        builder.append_null();
+                    }
+                } else {
+                    builder.append_null();
+                }
+            }
+            let ca = builder.finish();
+            ca.downcast_iter().cloned().collect::<Vec<_>>()
+        });
+        let chunks = POOL.install(|| chunks_iter.collect::<Vec<_>>());
+        ListChunked::from_chunk_iter("".into(), chunks.into_iter().flatten())
+    } else {
+        let mut builder =
+            ListPrimitiveChunkedBuilder::<UInt32Type>::new("".into(), nrows, 16, DataType::UInt32);
+        let mask_iter = keep_mask.iter().map(|b| b.unwrap_or(false));
+        for (b, p) in mask_iter.zip(data.chunks_exact(ncols)) {
+            if b {
+                if let Some(v) = tree.within(p, r, sort) {
+                    builder.append_values_iter(v.into_iter().map(|nb| nb.to_item()));
+                } else {
+                    builder.append_null();
+                }
+            } else {
+                builder.append_null();
+            }
+        }
+        builder.finish()
+    }
+}
+
+#[polars_expr(output_type_func=list_u32_output)]
+fn pl_query_radius_ptwise_null_safe(
+    inputs: &[Series],
+    context: CallerContext,
+    kwargs: KDTRadiusKwargs,
+) -> PolarsResult<Series> {
+    let can_parallel = kwargs.parallel && !context.parallel();
+    let radius = kwargs.r;
+    let sort = kwargs.sort;
+
+    let id = inputs[0].u32()?;
+    let id = id.cont_slice()?;
+    // True = row's features are all non-null and should be included in the kd-tree.
+    let keep_mask = inputs[1].bool()?;
+
+    let ncols = inputs[2..].len();
+    let data = series_to_slice::<Float64Type>(&inputs[2..], IndexOrder::C)?;
+    match KNNDist::try_from(kwargs.metric).map_err(|e| PolarsError::ComputeError(e.into())) {
+        Ok(d) => {
+            let mut leaves = row_major_slice_to_leaves_filtered(&data, ncols, id, keep_mask);
+            let tree = KDT::from_leaves(&mut leaves, d)
+                .map_err(|e| PolarsError::ComputeError(e.into()))?;
+            Ok(
+                query_radius_ptwise_null_safe(&tree, keep_mask, &data, radius, can_parallel, sort)
+                    .into_series(),
+            )
+        }
+        Err(e) => Err(PolarsError::ComputeError(e.to_string().into())),
+    }
+}
+
 #[inline]
 pub fn query_nb_cnt<'a, M: Metric>(
     tree: &KDT<'a, (), M>,

--- a/tests/test_many.py
+++ b/tests/test_many.py
@@ -1106,6 +1106,68 @@ def test_radius_ptwise(df, dist, res):
     assert_frame_equal(test, res)
 
 
+def test_radius_ptwise_null_safe_matches_clean():
+    # On null-free input, the null-safe variant must match the production symbol.
+    df = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "val1": [0.1, 0.2, 5.0],
+            "val2": [0.1, 0.3, 10.0],
+            "val3": [0.1, 0.4, 11.0],
+        }
+    )
+    a = df.select(
+        pds.query_radius_ptwise("val1", "val2", "val3", dist="sql2", r=0.3, index="id")
+    )
+    b = df.select(
+        pds.query_radius_ptwise_null_safe(
+            "val1", "val2", "val3", dist="sql2", r=0.3, index="id"
+        )
+    )
+    assert_frame_equal(a, b)
+
+
+def test_radius_ptwise_null_safe_with_nulls_no_panic():
+    # Production pl_query_radius_ptwise panics when feature columns contain nulls.
+    # The null-safe variant must skip null-feature rows on build and return null
+    # for null-feature query rows. Regression test for bug-029.
+    df = pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "val1": [0.1, None, 5.0, 0.2],
+            "val2": [0.1, 0.3, 10.0, None],
+            "val3": [0.1, 0.4, 11.0, 0.3],
+        }
+    )
+    out = df.select(
+        pds.query_radius_ptwise_null_safe(
+            "val1", "val2", "val3", dist="sql2", r=0.3, index="id"
+        ).alias("ids")
+    )
+    # Rows 2 (val1 null) and 4 (val2 null) must produce null in the output list.
+    assert out["ids"][1] is None
+    assert out["ids"][3] is None
+    # Rows 1 and 3 are the only fully-non-null rows; row 1 finds itself, row 3 finds itself.
+    assert out["ids"][0].to_list() == [1]
+    assert out["ids"][2].to_list() == [3]
+
+
+def test_radius_ptwise_null_safe_multichunk_with_nulls():
+    # Same scenario, but inputs have multiple chunks (catches rechunk-assumption bugs).
+    parts = [
+        pl.DataFrame({"id": [1, 2], "v1": [0.1, None], "v2": [0.1, 0.3]}),
+        pl.DataFrame({"id": [3, 4], "v1": [5.0, 0.2], "v2": [10.0, None]}),
+    ]
+    df = pl.concat(parts, rechunk=False)
+    out = df.select(
+        pds.query_radius_ptwise_null_safe("v1", "v2", dist="sql2", r=0.3, index="id").alias(
+            "ids"
+        )
+    )
+    assert out["ids"][1] is None
+    assert out["ids"][3] is None
+
+
 @pytest.mark.parametrize(
     "df, r, dist, res",
     [


### PR DESCRIPTION
## Summary

Fix for the long-standing panic when `pds.query_radius_ptwise` receives feature columns with nulls.

`pl_query_radius_ptwise` panics inside `kdt2.rs` (unwrap on `None`) when any feature column has nulls — the wrapper does no pre-filter, unlike `pds.query_knn_ptwise`, which builds a `keep_mask` and skips null-feature rows.

This PR adds an **opt-in null-safe variant** mirroring the `query_knn_ptwise` keep-mask pattern: rows where any feature column is null are excluded from the kd-tree (they cannot be neighbors anyway) and return `null` in the output list. The production `pl_query_radius_ptwise` is unchanged so existing callers are unaffected — null-safety is opt-in via the new `pds.query_radius_ptwise_null_safe` symbol.

Split out from #448 per @abstractqqq's request to take it more piecemeal. This is the highest user-impact slice; the remaining KNN micro-opts and other tier-2/3 work will follow in separate focused PRs.

## Files

- `src/num_ext/knn.rs` — new public Rust helper `query_radius_ptwise_null_safe` + polars_expr `pl_query_radius_ptwise_null_safe`. Reuses the existing `row_major_slice_to_leaves_filtered` helper already used by the `knn_ptwise` paths.
- `python/polars_ds/exprs/expr_knn.py` — new public wrapper `query_radius_ptwise_null_safe`, added to `__all__`.
- `tests/test_many.py` — three new tests:
  - parity vs production `query_radius_ptwise` on null-free input,
  - regression test for the panic on null-feature input,
  - multichunk-with-nulls variant.

## Test plan

- [x] `cargo check --lib` clean
- [x] `maturin develop` build clean
- [x] `pytest tests/test_many.py -k radius_ptwise` — 4 pass (1 existing + 3 new)