### PR TITLE
perf: drop to_lowercase allocations in From<&str> dispatch (+ small cleanups)

### DIFF
--- a/src/arkadia/mod.rs
+++ b/src/arkadia/mod.rs
@@ -38,12 +38,16 @@ pub enum KNNDist {
 impl TryFrom<String> for KNNDist {
     type Error = String;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        match value.to_lowercase().as_ref() {
-            "l1" => Ok(KNNDist::L1),
-            "sql2" => Ok(KNNDist::SQL2),
-            "l2" => Ok(KNNDist::L2),
-            "linf" | "inf" => Ok(KNNDist::LINF),
-            _ => Err(format!("Unknown distance indicator: {}", value)),
+        if value.eq_ignore_ascii_case("l1") {
+            Ok(KNNDist::L1)
+        } else if value.eq_ignore_ascii_case("sql2") {
+            Ok(KNNDist::SQL2)
+        } else if value.eq_ignore_ascii_case("l2") {
+            Ok(KNNDist::L2)
+        } else if value.eq_ignore_ascii_case("linf") || value.eq_ignore_ascii_case("inf") {
+            Ok(KNNDist::LINF)
+        } else {
+            Err(format!("Unknown distance indicator: {}", value))
         }
     }
 }

--- a/src/linear/glm/glm_solvers.rs
+++ b/src/linear/glm/glm_solvers.rs
@@ -48,12 +48,16 @@ impl GLMFamily {
 
 impl From<&str> for GLMFamily {
     fn from(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "gaussian" | "normal" => GLMFamily::Gaussian,
-            "poisson" => GLMFamily::Poisson,
-            "binomial" | "logistic" => GLMFamily::Binomial,
-            "gamma" => GLMFamily::Gamma,
-            _ => GLMFamily::Gaussian, // Default to Gaussian
+        if s.eq_ignore_ascii_case("gaussian") || s.eq_ignore_ascii_case("normal") {
+            GLMFamily::Gaussian
+        } else if s.eq_ignore_ascii_case("poisson") {
+            GLMFamily::Poisson
+        } else if s.eq_ignore_ascii_case("binomial") || s.eq_ignore_ascii_case("logistic") {
+            GLMFamily::Binomial
+        } else if s.eq_ignore_ascii_case("gamma") {
+            GLMFamily::Gamma
+        } else {
+            GLMFamily::Gaussian // Default to Gaussian
         }
     }
 }
@@ -258,7 +262,7 @@ pub fn faer_irls<T: RealField + Float>(
 
     // let epsilon = T::from(1e-8).unwrap();
     // Initialized mu based on variance
-    let point_5 = T::one() / (T::one() + T::one());
+    let point_5 = T::from(0.5).unwrap();
     let mut mu = match variance {
         VarianceFunction::Binomial => y
             .col(0)

--- a/src/linear/glm/mod.rs
+++ b/src/linear/glm/mod.rs
@@ -15,10 +15,12 @@ pub enum GLMSolverMethods {
 
 impl From<&str> for GLMSolverMethods {
     fn from(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "irls" => GLMSolverMethods::IRLS,
-            "lbfgs" => panic!("LBFGS not available"), // lbfgs not available
-            _ => GLMSolverMethods::IRLS,
+        if s.eq_ignore_ascii_case("irls") {
+            GLMSolverMethods::IRLS
+        } else if s.eq_ignore_ascii_case("lbfgs") {
+            panic!("LBFGS not available") // lbfgs not available
+        } else {
+            GLMSolverMethods::IRLS
         }
     }
 }

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -43,19 +43,23 @@ impl<T: Float + FromStr> TryFrom<String> for NullPolicy<T> {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let binding = value.to_lowercase();
-        let test = binding.as_ref();
-        match test {
-            "raise" => Ok(Self::RAISE),
-            "skip" => Ok(Self::SKIP),
-            "zero" => Ok(Self::FILL(T::zero())),
-            "one" => Ok(Self::FILL(T::one())),
-            "ignore" => Ok(Self::IGNORE),
-            "skip_window" => Ok(Self::SKIP_WINDOW),
-            _ => match test.parse::<T>() {
+        if value.eq_ignore_ascii_case("raise") {
+            Ok(Self::RAISE)
+        } else if value.eq_ignore_ascii_case("skip") {
+            Ok(Self::SKIP)
+        } else if value.eq_ignore_ascii_case("zero") {
+            Ok(Self::FILL(T::zero()))
+        } else if value.eq_ignore_ascii_case("one") {
+            Ok(Self::FILL(T::one()))
+        } else if value.eq_ignore_ascii_case("ignore") {
+            Ok(Self::IGNORE)
+        } else if value.eq_ignore_ascii_case("skip_window") {
+            Ok(Self::SKIP_WINDOW)
+        } else {
+            match value.parse::<T>() {
                 Ok(x) => Ok(Self::FILL(x)),
                 Err(_) => Err("Invalid NullPolicy.".into()),
-            },
+            }
         }
     }
 }

--- a/src/num_ext/float_extras.rs
+++ b/src/num_ext/float_extras.rs
@@ -198,21 +198,19 @@ fn pl_trunc(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type_func=float_output)]
 fn pl_fract(inputs: &[Series]) -> PolarsResult<Series> {
     let s = &inputs[0];
-
-    if s.dtype().is_integer() {
-        Ok(Series::from_vec(s.name().clone(), vec![0f32; s.len()]))
-    } else {
-        if s.dtype() == &DataType::Float64 {
+    match s.dtype() {
+        DataType::Float64 => {
             let ca = s.f64().unwrap();
             Ok(ca.apply_values(f64::fract).into_series())
-        } else if s.dtype() == &DataType::Float32 {
+        }
+        DataType::Float32 => {
             let ca = s.f32().unwrap();
             Ok(ca.apply_values(f32::fract).into_series())
-        } else {
-            Err(PolarsError::ComputeError(
-                "Input column must be numerical.".into(),
-            ))
         }
+        dt if dt.is_integer() => Ok(Series::from_vec(s.name().clone(), vec![0f32; s.len()])),
+        _ => Err(PolarsError::ComputeError(
+            "Input column must be numerical.".into(),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Replace `match s.to_lowercase().as_str()` with `if/else if` chains over `s.eq_ignore_ascii_case(...)` across the four dispatcher impls. The old form allocates a `String` per call; the new form compares in place. Each of these dispatchers is called once per Polars expression call, so the alloc shows up in group_by-style workloads with many small groups (e.g. `group_by` GLM, KNN, or `lin_reg` over thousands of partitions).

Same arm mappings; only the comparison method changes. Public behavior unchanged for all valid inputs; the error message for unknown strings is unchanged.

Bundled in the same theme:
- `faer_irls`: replace `T::one() / (T::one() + T::one())` with `T::from(0.5).unwrap()` — one trait call vs three.
- `pl_fract`: collapse the dtype-check pyramid into a single `match s.dtype()`, mirroring `pl_trunc` directly above it.

Split out from #448 per @abstractqqq's request.

## Files

- `src/arkadia/mod.rs` — `KNNDist::try_from`
- `src/linear/glm/glm_solvers.rs` — `GLMFamily::from` + `T::from(0.5)`
- `src/linear/glm/mod.rs` — `GLMSolverMethods::from`
- `src/linear/mod.rs` — `NullPolicy::try_from`
- `src/num_ext/float_extras.rs` — `pl_fract` dispatch shape

## Test plan

- [x] `cargo check --lib` clean (no new warnings)
- [x] `maturin develop` build clean
- [x] `pytest -k "glm or null_policy or knn or fract or radius or float_op"` — 9 pass