### PR TITLE
perf: fuse dtype/length validation; skip unconditional rechunk in PSI

### DIFF
--- a/src/num_ext/psi.rs
+++ b/src/num_ext/psi.rs
@@ -79,13 +79,24 @@ fn pl_psi_w_bps(inputs: &[Series]) -> PolarsResult<Series> {
     let data2 = inputs[1].f64().unwrap();
     let breakpoints = inputs[2].f64().unwrap();
 
-    let binding = data1.rechunk();
-    let s1 = binding.cont_slice().unwrap();
-    let binding = data2.rechunk();
-    let s2 = binding.cont_slice().unwrap();
-
-    let binding = breakpoints.rechunk();
-    let bp = binding.cont_slice().unwrap();
+    let binding1 = if data1.chunks().len() == 1 {
+        data1.clone()
+    } else {
+        data1.rechunk().into_owned()
+    };
+    let s1 = binding1.cont_slice().unwrap();
+    let binding2 = if data2.chunks().len() == 1 {
+        data2.clone()
+    } else {
+        data2.rechunk().into_owned()
+    };
+    let s2 = binding2.cont_slice().unwrap();
+    let binding_bp = if breakpoints.chunks().len() == 1 {
+        breakpoints.clone()
+    } else {
+        breakpoints.rechunk().into_owned()
+    };
+    let bp = binding_bp.cont_slice().unwrap();
 
     let c1 = psi_with_bps_helper(s1, bp);
     let c2 = psi_with_bps_helper(s2, bp);
@@ -104,12 +115,24 @@ fn pl_psi_report(inputs: &[Series]) -> PolarsResult<Series> {
     // The cnts for the baseline/reference
     let cnt = inputs[2].u32().unwrap();
 
-    let binding = new.rechunk();
-    let data_new = binding.cont_slice().unwrap();
-    let binding = brk.rechunk();
-    let ref_brk = binding.cont_slice().unwrap();
-    let binding = cnt.rechunk();
-    let ref_cnt = binding.cont_slice().unwrap();
+    let binding_new = if new.chunks().len() == 1 {
+        new.clone()
+    } else {
+        new.rechunk().into_owned()
+    };
+    let data_new = binding_new.cont_slice().unwrap();
+    let binding_brk = if brk.chunks().len() == 1 {
+        brk.clone()
+    } else {
+        brk.rechunk().into_owned()
+    };
+    let ref_brk = binding_brk.cont_slice().unwrap();
+    let binding_cnt = if cnt.chunks().len() == 1 {
+        cnt.clone()
+    } else {
+        cnt.rechunk().into_owned()
+    };
+    let ref_cnt = binding_cnt.cont_slice().unwrap();
 
     let new_cnt = psi_with_bps_helper(data_new, ref_brk);
     let psi_report = psi_frame(ref_brk, "<=", ref_cnt, &new_cnt)?.collect()?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,4 @@
 use crate::utils::parallelism::SMALL_INPUT_THRESHOLD;
-use itertools::Itertools;
 // use cfavml::safe_trait_distance_ops::DistanceOps;
 use num::Float;
 use polars::{
@@ -58,15 +57,19 @@ where
     if series.is_empty() {
         return Err(PolarsError::NoData("Data is empty".into()));
     }
-    if series.iter().any(|s| !s.dtype().is_numeric()) {
-        return Err(PolarsError::ComputeError(
-            "All columns need to be numeric.".into(),
-        ));
-    }
-    if !series.iter().map(|s| s.len()).all_equal() {
-        return Err(PolarsError::ShapeMismatch(
-            "Seires don't have the same length.".into(),
-        ));
+    // Fuse the numeric-dtype check and the length-equality check into a single pass.
+    let first_len = series[0].len();
+    for s in series.iter() {
+        if !s.dtype().is_numeric() {
+            return Err(PolarsError::ComputeError(
+                "All columns need to be numeric.".into(),
+            ));
+        }
+        if s.len() != first_len {
+            return Err(PolarsError::ShapeMismatch(
+                "Seires don't have the same length.".into(),
+            ));
+        }
     }
     series_to_slice_inner::<N>(series, ordering, extra_cap)
 }


### PR DESCRIPTION
## Summary

Two small redundancy removals split out from #448.

**`src/utils/mod.rs` — fuse dtype + length validation.** `series_to_slice_with_extra_cap` previously walked the input series twice: once with `series.iter().any(|s| !s.dtype().is_numeric())` and again with `series.iter().map(|s| s.len()).all_equal()`. Combine both checks into a single `for s in series.iter()` loop. Same errors raised for the same inputs. Drops the now-unused `itertools::Itertools` import.

**`src/num_ext/psi.rs` — conditional rechunk.** `pl_psi_w_bps` and `pl_psi_report` previously called `.rechunk()` on every input unconditionally, even when the input was already single-chunk (the typical plugin-arg shape after polars hands data to the expression). Add a `chunks().len() == 1` guard so single-chunk inputs skip the contiguous-copy. Multi-chunk inputs still rechunk as before.

Both are O(input)-saving micro-cleanups individually; together they trim a slice off `series_to_slice` callers and the PSI hot paths.

## Test plan

- [x] `cargo check --lib` clean (warning count unchanged at 23)
- [x] `maturin develop` build clean
- [x] `pytest -k "psi or lin_reg or knn or radius or float"` — 25 pass