### PR TITLE
test: cover NullPolicy, KNN dist variants, GLM families, f32 LR, multi-pred, PSI

### DIFF
--- a/tests/test_linear_exprs.py
+++ b/tests/test_linear_exprs.py
@@ -309,6 +309,104 @@ def test_f32_lin_reg():
     pds.config.LIN_REG_EXPR_F64 = True
 
 
+def test_f32_lin_reg_against_sklearn():
+    """f32 path (LIN_REG_EXPR_F64=False) produces coefficients close to sklearn OLS."""
+    from sklearn import linear_model
+
+    pds.config.LIN_REG_EXPR_F64 = False
+    try:
+        df = (
+            pds.frame(size=5_000)
+            .select(
+                pds.random(0.0, 1.0).alias("x1"),
+                pds.random(0.0, 1.0).alias("x2"),
+                pds.random(0.0, 1.0).alias("x3"),
+            )
+            .with_columns(
+                y=pl.col("x1") * 0.5
+                + pl.col("x2") * 0.1
+                - pl.col("x3") * 0.15
+                + pds.random() * 0.0001
+            )
+        )
+
+        x = df.select("x1", "x2", "x3").to_numpy()
+        y = df["y"].to_numpy()
+
+        # OLS with bias
+        reg = linear_model.LinearRegression(fit_intercept=True)
+        reg.fit(x, y)
+        normal_coeffs = df.select(
+            pds.lin_reg("x1", "x2", "x3", target="y", add_bias=True).alias("pred")
+        ).explode("pred")
+        all_coeffs = normal_coeffs["pred"].to_numpy()
+        assert np.all(np.abs(all_coeffs[:3] - reg.coef_) < 1e-4)
+        assert abs(all_coeffs[-1] - reg.intercept_) < 1e-4
+
+        # Ridge with bias
+        reg_ridge = linear_model.Ridge(alpha=0.1, fit_intercept=True)
+        reg_ridge.fit(x, y)
+        ridge_coeffs = df.select(
+            pds.lin_reg("x1", "x2", "x3", target="y", l2_reg=0.1, add_bias=True).alias("pred")
+        ).explode("pred")
+        all_ridge = ridge_coeffs["pred"].to_numpy()
+        assert np.all(np.abs(all_ridge[:3] - reg_ridge.coef_) < 1e-3)
+        assert abs(all_ridge[-1] - reg_ridge.intercept_) < 1e-3
+
+        # Predictions
+        pred_result = df.select(
+            pds.lin_reg("x1", "x2", "x3", target="y", add_bias=True, return_pred=True).alias(
+                "lr_pred"
+            )
+        ).unnest("lr_pred")
+        assert np.all(np.abs(pred_result["pred"].to_numpy() - reg.predict(x)) < 1e-3)
+
+        # lin_reg_report runs without error and returns finite betas in f32 mode
+        report = df.select(
+            pds.lin_reg_report("x1", "x2", "x3", target="y", add_bias=True).alias("r")
+        ).unnest("r")
+        betas = np.array(report["beta"].to_list())
+        assert np.all(np.isfinite(betas))
+        assert np.all(np.abs(betas[:3] - reg.coef_) < 1e-3)
+    finally:
+        pds.config.LIN_REG_EXPR_F64 = True
+
+
+def test_pl_lr_multi_pred_correctness():
+    """Multi-target return_pred=True predictions match per-target single-target fits."""
+    rng = np.random.default_rng(42)
+    n = 1000
+    X = rng.standard_normal((n, 5))
+    true_betas = np.array(
+        [
+            [0.5, -0.2, 0.1, 0.3, -0.4],
+            [0.1, 0.6, -0.3, 0.0, 0.2],
+            [-0.2, 0.0, 0.7, -0.1, 0.3],
+        ]
+    )
+    Y = X @ true_betas.T + 0.01 * rng.standard_normal((n, 3))
+    df = pl.DataFrame(
+        {f"x{i + 1}": X[:, i] for i in range(5)} | {"y1": Y[:, 0], "y2": Y[:, 1], "y3": Y[:, 2]}
+    )
+    features = [f"x{i + 1}" for i in range(5)]
+
+    multi = df.select(
+        pds.lin_reg(*features, target=["y1", "y2", "y3"], return_pred=True).alias("lr_pred")
+    ).unnest("lr_pred")
+
+    for i, target in enumerate(["y1", "y2", "y3"]):
+        single = df.select(
+            pds.lin_reg(*features, target=target, return_pred=True).alias("lr_pred")
+        ).unnest("lr_pred")
+        np.testing.assert_allclose(
+            multi[f"target_{i}_pred"].to_numpy(),
+            single["pred"].to_numpy(),
+            rtol=0,
+            atol=1e-8,
+            err_msg=f"multi-pred for target_{i} ({target}) differs from per-target fit",
+        )
+
+
 def test_lin_reg_skip_null():
     df = pl.DataFrame(
         {

--- a/tests/test_linear_models.py
+++ b/tests/test_linear_models.py
@@ -188,3 +188,84 @@ def test_glm():
 
     assert abs(sm_bias - pds_bias) < 1e-6
     np.testing.assert_allclose(sm_coeffs, pds_coeffs, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "family,sm_family_cls,y_gen",
+    [
+        (
+            "gaussian",
+            "Gaussian",
+            lambda X, rng: X @ np.array([1.0, -0.5, 0.3, 0.8]) + rng.randn(X.shape[0]) * 0.1,
+        ),
+        (
+            "binomial",
+            "Binomial",
+            lambda X, rng: rng.binomial(
+                1,
+                1.0 / (1.0 + np.exp(-(X @ np.array([1.0, -0.5, 0.3, 0.8])))),
+            ).astype(float),
+        ),
+        (
+            "poisson",
+            "Poisson",
+            lambda X, rng: rng.poisson(
+                np.exp(np.clip(X @ np.array([0.5, -0.25, 0.15, 0.4]), -2.0, 2.0))
+            ).astype(float),
+        ),
+        (
+            "gamma",
+            "Gamma",
+            lambda X, rng: rng.gamma(
+                shape=2.0,
+                scale=np.exp(np.clip(X @ np.array([0.3, -0.15, 0.09, 0.24]), -2.0, 2.0)) / 2.0,
+            ),
+        ),
+    ],
+)
+def test_glm_family(family, sm_family_cls, y_gen):
+    """All four GLM families produce coefficients close to statsmodels."""
+    import statsmodels.api as sm
+    from polars_ds.linear_models import GLM
+
+    rng = np.random.RandomState(42)
+    n, p = 500, 4
+    X = rng.randn(n, p)
+    y = y_gen(X, rng)
+
+    X_with_const = sm.add_constant(X)
+    sm_family = getattr(sm.families, sm_family_cls)()
+    sm_glm = sm.GLM(y, X_with_const, family=sm_family).fit()
+    sm_bias = sm_glm.params[0]
+    sm_coeffs = sm_glm.params[1:]
+
+    pds_glm = GLM(solver="irls", add_bias=True, family=family, max_iter=200, tol=1e-8)
+    pds_glm.fit(X, y.reshape(-1, 1))
+    pds_coeffs = pds_glm.coeffs()
+    pds_bias = pds_glm.bias()
+
+    np.testing.assert_allclose(
+        pds_coeffs,
+        sm_coeffs,
+        atol=1e-2,
+        err_msg=f"GLM family={family!r}: coefficients differ from statsmodels by more than atol=1e-2",
+    )
+    assert abs(pds_bias - sm_bias) < 1e-2
+
+
+def test_glm_convergence_failure():
+    """GLM with max_iter=1 and tight tol does not crash; returns finite coeffs."""
+    from polars_ds.linear_models import GLM
+
+    rng = np.random.RandomState(0)
+    n, p = 200, 5
+    X = rng.randn(n, p)
+    y = np.exp(np.clip(X @ np.ones(p) * 0.2, -2, 2)) + rng.exponential(0.5, n)
+    y = y.reshape(-1, 1)
+
+    glm = GLM(solver="irls", add_bias=False, family="poisson", max_iter=1, tol=1e-12)
+    glm.fit(X, y)
+
+    coeffs = glm.coeffs()
+    assert coeffs is not None
+    assert np.all(np.isfinite(coeffs))

--- a/tests/test_many.py
+++ b/tests/test_many.py
@@ -1499,3 +1499,148 @@ def test_weighted_corr():
     pds_result = df.select(pds.weighted_corr("a1", "a2", "w")).item(0, 0)
 
     np.isclose(np_result, pds_result, atol=1e-8)
+
+
+# KNNDist variants and NullPolicy parameterized tests
+
+@pytest.mark.parametrize("dist", ["l1", "l2", "sql2", "linf"])
+def test_knn_dist_variants(dist):
+    """KNN ptwise runs without error for each KDTree-supported dist string."""
+    rng = np.random.default_rng(0)
+    n = 10
+    df = pl.DataFrame(
+        {
+            "id": list(range(n)),
+            "f0": rng.random(n).tolist(),
+            "f1": rng.random(n).tolist(),
+            "f2": rng.random(n).tolist(),
+        }
+    )
+    k = 3
+    result = df.select(
+        pds.query_knn_ptwise("f0", "f1", "f2", index="id", dist=dist, k=k).alias("nn")
+    )
+    assert result.shape == (n, 1)
+    for i, cell in enumerate(result["nn"]):
+        assert cell is not None, f"Row {i} returned None for dist={dist}"
+        indices = cell.to_list()
+        assert len(indices) <= k + 1
+        for idx in indices:
+            assert 0 <= idx < n
+
+
+def test_knn_dist_invalid_string():
+    """Unknown distance string must raise (not silently return garbage)."""
+    df = pl.DataFrame(
+        {
+            "id": list(range(5)),
+            "f0": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "f1": [0.5, 0.4, 0.3, 0.2, 0.1],
+            "f2": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+    with pytest.raises(Exception) as exc_info:
+        df.select(
+            pds.query_knn_ptwise(
+                "f0", "f1", "f2", index="id", dist="not_a_real_metric", k=2
+            ).alias("nn")
+        )
+    msg = str(exc_info.value).lower()
+    assert "not_a_real_metric" in msg or "unknown" in msg or "invalid" in msg
+
+
+def _make_null_policy_df():
+    """Small deterministic frame with nulls in x1 only."""
+    rng = np.random.default_rng(7)
+    n = 200
+    x1 = rng.random(n)
+    x2 = rng.random(n)
+    x3 = rng.random(n)
+    y = 0.5 * x1 + 0.3 * x2 - 0.2 * x3 + rng.random(n) * 0.001
+    null_rows = set(range(0, n, 10))
+    x1_with_nulls = [None if i in null_rows else float(v) for i, v in enumerate(x1)]
+    return pl.DataFrame(
+        {
+            "x1": pl.Series(x1_with_nulls, dtype=pl.Float64),
+            "x2": x2.tolist(),
+            "x3": x3.tolist(),
+            "y": y.tolist(),
+        }
+    )
+
+
+def _lin_reg_coeffs(df: pl.DataFrame) -> np.ndarray:
+    return (
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y").alias("c"))
+        .explode("c")["c"]
+        .to_numpy()
+    )
+
+
+def test_null_policy_skip():
+    df = _make_null_policy_df()
+    got = (
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y", null_policy="skip").alias("c"))
+        .explode("c")["c"]
+        .to_numpy()
+    )
+    ref = _lin_reg_coeffs(df.filter(pl.col("x1").is_not_null()))
+    assert np.allclose(got, ref, atol=1e-8)
+
+
+def test_null_policy_raise():
+    df = _make_null_policy_df()
+    with pytest.raises(Exception):
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y", null_policy="raise").alias("c"))
+
+
+def test_null_policy_zero():
+    df = _make_null_policy_df()
+    got = (
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y", null_policy="zero").alias("c"))
+        .explode("c")["c"]
+        .to_numpy()
+    )
+    ref = _lin_reg_coeffs(df.with_columns(pl.col("x1").fill_null(0.0)))
+    assert np.allclose(got, ref, atol=1e-8)
+
+
+def test_null_policy_one():
+    df = _make_null_policy_df()
+    got = (
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y", null_policy="one").alias("c"))
+        .explode("c")["c"]
+        .to_numpy()
+    )
+    ref = _lin_reg_coeffs(df.with_columns(pl.col("x1").fill_null(1.0)))
+    assert np.allclose(got, ref, atol=1e-8)
+
+
+def test_null_policy_numeric_fill():
+    df = _make_null_policy_df()
+    got = (
+        df.select(pds.lin_reg("x1", "x2", "x3", target="y", null_policy="0.5").alias("c"))
+        .explode("c")["c"]
+        .to_numpy()
+    )
+    ref = _lin_reg_coeffs(df.with_columns(pl.col("x1").fill_null(0.5)))
+    assert np.allclose(got, ref, atol=1e-8)
+
+
+def test_null_policy_ignore():
+    """IGNORE passes nulls to the solver; assert no panic and 3 coeffs returned."""
+    df = _make_null_policy_df()
+    result = df.select(
+        pds.lin_reg("x1", "x2", "x3", target="y", null_policy="ignore").alias("c")
+    ).explode("c")["c"]
+    assert len(result) == 3
+
+
+def test_null_policy_invalid():
+    df = _make_null_policy_df()
+    with pytest.raises(Exception) as exc_info:
+        df.select(
+            pds.lin_reg("x1", "x2", "x3", target="y", null_policy="not_a_policy").alias("c")
+        )
+    msg = str(exc_info.value).lower()
+    assert "invalid" in msg or "nullpolicy" in msg or "policy" in msg

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -347,3 +347,80 @@ def test_ndcg_score():
 
         sklearn_results = np.array(sklearn_results)
         np.testing.assert_allclose(df_agg["ndcg_score"].to_numpy(), sklearn_results, rtol=1e-5)
+
+
+# PSI tests
+# pl_psi_w_bps is exposed as pds.psi_w_breakpoints(new, baseline, breakpoints).
+# Always returns a struct report; the caller sums psi_bin to get the scalar.
+# Both baseline_pct and actual_pct are clipped to a minimum of 0.0001 inside
+# the Rust kernel, which is why identical-distribution PSI may not be exactly 0.
+
+def _reference_psi(new_arr, baseline_arr, breakpoints):
+    """Independent Python PSI; returns (per_bin, scalar)."""
+    bp = list(breakpoints) + [float("inf")]
+
+    def bucket_counts(arr, bp):
+        counts = np.zeros(len(bp), dtype=np.float64)
+        for v in arr:
+            idx = np.searchsorted(bp, v, side="left")
+            counts[idx] += 1
+        return counts
+
+    baseline_counts = bucket_counts(baseline_arr, bp)
+    new_counts = bucket_counts(new_arr, bp)
+    baseline_pct = np.maximum(baseline_counts / baseline_counts.sum(), 0.0001)
+    actual_pct = np.maximum(new_counts / new_counts.sum(), 0.0001)
+    per_bin = (baseline_pct - actual_pct) * np.log(baseline_pct / actual_pct)
+    return per_bin, per_bin.sum()
+
+
+def test_psi_w_breakpoints():
+    """psi_w_breakpoints scalar matches independent Python reference."""
+    rng = np.random.default_rng(42)
+    baseline = rng.normal(loc=0.0, scale=1.0, size=1000)
+    new = rng.normal(loc=0.5, scale=1.2, size=1000)
+    bps = list(np.quantile(baseline, [0.25, 0.50, 0.75]))
+
+    df = pl.DataFrame({"new": new, "baseline": baseline})
+    report = df.select(pds.psi_w_breakpoints("new", "baseline", breakpoints=bps)).unnest(
+        "psi_report"
+    )
+    psi_scalar = report["psi_bin"].sum()
+
+    assert np.isfinite(psi_scalar)
+    assert psi_scalar > 0
+
+    _, ref_psi = _reference_psi(new, baseline, bps)
+    assert np.isclose(psi_scalar, ref_psi, atol=1e-10), (
+        f"PSI mismatch: got {psi_scalar}, expected {ref_psi}"
+    )
+
+
+def test_psi_w_breakpoints_identical_distributions():
+    """When new == baseline, PSI should be ~0 (clip floor only fires on empty bins)."""
+    rng = np.random.default_rng(7)
+    data = rng.normal(size=1000)
+    bps = list(np.quantile(data, [0.25, 0.50, 0.75]))
+    df = pl.DataFrame({"a": data, "b": data})
+    report = df.select(pds.psi_w_breakpoints("a", "b", breakpoints=bps)).unnest("psi_report")
+    psi_scalar = report["psi_bin"].sum()
+    assert np.isclose(psi_scalar, 0.0, atol=1e-12)
+
+
+def test_psi_report_struct():
+    """psi(..., return_report=True) struct's per-bin PSI sums to the scalar path."""
+    rng = np.random.default_rng(99)
+    baseline = rng.normal(loc=0.0, scale=1.0, size=1000)
+    new = rng.normal(loc=0.3, scale=1.1, size=1000)
+    df = pl.DataFrame({"new": new, "baseline": baseline})
+
+    report = df.select(pds.psi("new", "baseline", n_bins=10, return_report=True)).unnest(
+        "psi_report"
+    )
+    expected_fields = {"<=", "baseline_pct", "actual_pct", "psi_bin"}
+    assert expected_fields <= set(report.columns)
+    assert report.shape[0] == 10
+
+    struct_psi = report["psi_bin"].sum()
+    scalar_psi = df.select(pds.psi("new", "baseline", n_bins=10)).item(0, 0)
+    assert np.isclose(struct_psi, scalar_psi, atol=1e-10)


### PR DESCRIPTION
## Summary

Pure test additions — no production code changes. Split out from #448 per @abstractqqq's request.

Fills coverage gaps the audit identified while working on the perf cleanups in the parent PR. Each test compares either against an independent reference (sklearn / statsmodels / hand-written numpy reference) or against a different code path in this repo (single-target vs. multi-target, scalar PSI vs. struct-PSI, `null_policy=\"skip\"` vs. manually-filtered fit).

## Files

- `tests/test_linear_exprs.py` — 2 new tests:
  - `test_f32_lin_reg_against_sklearn` — the f32 path had only smoke-test coverage previously; this compares OLS, Ridge, predictions, and `lin_reg_report` against sklearn at f32-appropriate tolerances.
  - `test_pl_lr_multi_pred_correctness` — multi-target `return_pred=True` was previously discarded with `_ = ...`; now compared element-wise to per-target single-target fits.

- `tests/test_linear_models.py` — 2 new tests (1 parametrized over 4 families):
  - `test_glm_family` — parametrized over gaussian / binomial / poisson / gamma (was gamma-only previously). Compared against statsmodels.
  - `test_glm_convergence_failure` — documents that `max_iter=1, tol=1e-12` doesn't panic and returns finite coefficients.

- `tests/test_metrics.py` — 3 new PSI tests (`pl_psi_w_bps` had zero tests prior):
  - `test_psi_w_breakpoints` — scalar PSI vs independent Python reference.
  - `test_psi_w_breakpoints_identical_distributions` — PSI ≈ 0 sanity check.
  - `test_psi_report_struct` — struct-output path; sum of bin-PSI matches scalar `pds.psi(...)`.

- `tests/test_many.py` — KNN dist variants + NullPolicy parametrized:
  - `test_knn_dist_variants` (parametrized over `[\"l1\", \"l2\", \"sql2\", \"linf\"]`).
  - `test_knn_dist_invalid_string` — error path for unknown metric strings.
  - `test_null_policy_*` — `skip / raise / zero / one / 0.5 / ignore / invalid`, each comparing against a manually-filtered or filled reference fit.

## Test plan

- [x] `maturin develop` builds clean
- [x] All 22 newly-added test functions pass

## Notes

This PR adds tests only and is independent of the other split-out PRs from #448. Some tests exercise the same dispatch surface that is being micro-optimised in #453, but the assertions are about behaviour, so they pass against current main as well.