### PR TITLE
perf: drop redundant work in pl_nb_cnt + knn_ptwise_w_dist

### DIFF
--- a/src/num_ext/knn.rs
+++ b/src/num_ext/knn.rs
@@ -358,12 +358,15 @@ where
                     );
                     let subslice = &data[offset * ncols..(offset + len) * ncols];
                     let mask = &eval_mask[offset..offset + len];
+                    // Reusable scratch buffers; one heap alloc per thread instead of per matched row.
+                    let mut distances: Vec<f64> = Vec::with_capacity(k + 1);
+                    let mut neighbors: Vec<u32> = Vec::with_capacity(k + 1);
                     for (b, p) in mask.iter().zip(subslice.chunks_exact(ncols)) {
                         if *b {
                             match tree.knn_bounded(k + 1, p, max_bound, epsilon) {
                                 Some(nbs) => {
-                                    let mut distances = Vec::with_capacity(nbs.len());
-                                    let mut neighbors = Vec::with_capacity(nbs.len());
+                                    distances.clear();
+                                    neighbors.clear();
                                     for (d, id) in nbs.into_iter().map(|nb| nb.to_pair()) {
                                         distances.push(d);
                                         neighbors.push(id);
@@ -408,14 +411,15 @@ where
             k + 1,
             DataType::Float64,
         );
+        // Reusable scratch buffers hoisted out of the row loop.
+        let mut distances: Vec<f64> = Vec::with_capacity(k + 1);
+        let mut neighbors: Vec<u32> = Vec::with_capacity(k + 1);
         for (b, p) in eval_mask.into_iter().zip(data.chunks_exact(ncols)) {
             if b {
                 match tree.knn_bounded(k + 1, p, max_bound, epsilon) {
                     Some(nbs) => {
-                        // let v = nbs.into_iter().map(|nb| nb.to_item()).collect::<Vec<u32>>();
-                        // builder.append_slice(&v);
-                        let mut distances = Vec::with_capacity(nbs.len());
-                        let mut neighbors = Vec::with_capacity(nbs.len());
+                        distances.clear();
+                        neighbors.clear();
                         for (d, id) in nbs.into_iter().map(|nb| nb.to_pair()) {
                             distances.push(d);
                             neighbors.push(id);
@@ -673,31 +677,22 @@ fn pl_nb_cnt(inputs: &[Series], context: CallerContext, kwargs: KDTKwargs) -> Po
     let data = series_to_slice::<Float64Type>(&inputs[1..], IndexOrder::C)?;
     let nrows = data.len() / ncols;
 
+    let dist = KNNDist::try_from(kwargs.metric).map_err(|e| PolarsError::ComputeError(e.into()))?;
     if radius.len() == 1 {
         let r = radius.get(0).unwrap();
-        match KNNDist::try_from(kwargs.metric).map_err(|e| PolarsError::ComputeError(e.into())) {
-            Ok(d) => {
-                let mut leaves = slice_to_empty_leaves(&data, ncols);
-                let tree = KDT::from_leaves(&mut leaves, d)
-                    .map_err(|e| PolarsError::ComputeError(e.into()))?;
-                Ok(query_nb_cnt(&tree, &data, r, can_parallel)
-                    .with_name("cnt".into())
-                    .into_series())
-            }
-            Err(e) => Err(PolarsError::ComputeError(e.to_string().into())),
-        }
+        let mut leaves = slice_to_empty_leaves(&data, ncols);
+        let tree = KDT::from_leaves(&mut leaves, dist)
+            .map_err(|e| PolarsError::ComputeError(e.into()))?;
+        Ok(query_nb_cnt(&tree, &data, r, can_parallel)
+            .with_name("cnt".into())
+            .into_series())
     } else if radius.len() == nrows {
-        match KNNDist::try_from(kwargs.metric).map_err(|e| PolarsError::ComputeError(e.into())) {
-            Ok(d) => {
-                let mut leaves = slice_to_empty_leaves(&data, ncols);
-                let tree = KDT::from_leaves(&mut leaves, d)
-                    .map_err(|e| PolarsError::ComputeError(e.into()))?;
-                Ok(query_nb_cnt_w_radius(&tree, &data, radius, can_parallel)
-                    .with_name("cnt".into())
-                    .into_series())
-            }
-            Err(e) => Err(PolarsError::ComputeError(e.to_string().into())),
-        }
+        let mut leaves = slice_to_empty_leaves(&data, ncols);
+        let tree = KDT::from_leaves(&mut leaves, dist)
+            .map_err(|e| PolarsError::ComputeError(e.into()))?;
+        Ok(query_nb_cnt_w_radius(&tree, &data, radius, can_parallel)
+            .with_name("cnt".into())
+            .into_series())
     } else {
         Err(PolarsError::ShapeMismatch(
             "Inputs must have the same length or one of them must be a scalar.".into(),


### PR DESCRIPTION
## Summary

Two small redundancy removals split out from #448 as a follow-up to #452 (they touch overlapping regions of `src/num_ext/knn.rs`).

**`pl_nb_cnt`** — `KNNDist::try_from(kwargs.metric)` was called once in the `radius.len() == 1` branch and again in the `radius.len() == nrows` branch. Hoist the parse above the branch so it runs at most once. The error path is preserved (now via `?` instead of an inner `match`).

**`knn_ptwise_w_dist`** — the `distances` and `neighbors` scratch `Vec`s were allocated per matched row inside the row loop, both on the parallel chunk path and the serial path. For N matched rows this was 2N heap allocations. Hoist them out of the loop and `clear()` per iteration — one allocation per thread (parallel) or one per call (serial). Capacity is preserved at `k + 1`. No change to output values or row order.

## Suggested merge order

This PR edits `src/num_ext/knn.rs` near where #452 inserts the new null-safe radius helpers. **Please merge #452 first** — this PR will rebase cleanly on top of it.

## Test plan

- [x] `cargo check --lib` clean (warning count unchanged at 23)
- [x] `maturin develop` build clean
- [x] `pytest -k "knn or radius or nb_cnt"` — 10 pass