### PR TITLE
[Enhancement]: optional singular_x_tol rank-deficiency gate for lin_reg (#461) + rcond solve speedup

### DIFF
--- a/benchmarks/test_linear_regression.py
+++ b/benchmarks/test_linear_regression.py
@@ -177,3 +177,31 @@ def test_sklearn_ridge_cholesky_on_df(benchmark, n):
     def func():
         reg = Ridge(alpha=0.1, fit_intercept=False, solver="cholesky")
         reg.fit(df[X_VARS], df[Y])
+
+
+# Gate overhead: the singular_x_tol gate (default 1e-12, on) must not regress vs
+# singular_x_tol=0.0 (gate fully off). Both run on the same well-conditioned data
+# inside an expression so the X'X build + solve dominate; the gate only adds one
+# k x k determinant. Compare the two groups at each size.
+@pytest.mark.parametrize("n", SIZES)
+@pytest.mark.benchmark(group="linreg_singular_gate")
+def test_pds_lin_reg_gate_on(benchmark, n):
+    df = DF.sample(n=n, seed=SEED)
+
+    @benchmark
+    def func():
+        df.select(
+            pds.lin_reg(*X_VARS, target="y", add_bias=False, singular_x_tol=1e-12).alias("c")
+        )
+
+
+@pytest.mark.parametrize("n", SIZES)
+@pytest.mark.benchmark(group="linreg_singular_gate")
+def test_pds_lin_reg_gate_off(benchmark, n):
+    df = DF.sample(n=n, seed=SEED)
+
+    @benchmark
+    def func():
+        df.select(
+            pds.lin_reg(*X_VARS, target="y", add_bias=False, singular_x_tol=0.0).alias("c")
+        )

--- a/benchmarks/test_linear_regression.py
+++ b/benchmarks/test_linear_regression.py
@@ -181,8 +181,9 @@ def test_sklearn_ridge_cholesky_on_df(benchmark, n):
 
 # Gate overhead: the singular_x_tol gate (default 1e-12, on) must not regress vs
 # singular_x_tol=0.0 (gate fully off). Both run on the same well-conditioned data
-# inside an expression so the X'X build + solve dominate; the gate only adds one
-# k x k determinant. Compare the two groups at each size.
+# inside an expression so the X'X build + solve dominate. The gate reuses the
+# solver's own factorization (no separate determinant), so it adds only k logs.
+# Compare the two groups at each size.
 @pytest.mark.parametrize("n", SIZES)
 @pytest.mark.benchmark(group="linreg_singular_gate")
 def test_pds_lin_reg_gate_on(benchmark, n):

--- a/python/polars_ds/exprs/expr_linear.py
+++ b/python/polars_ds/exprs/expr_linear.py
@@ -115,7 +115,7 @@ def lin_reg(
     max_iter: int = 200,
     null_policy: NullPolicy = "skip",
     positive: bool = False,
-    singular_x_tol: float = 1e-12,
+    singular_x_tol: float | None = None,
 ) -> pl.Expr:
     """
     Computes linear regression solution to the equation Ax = y where y is the target (or multiple targets).
@@ -168,15 +168,22 @@ def lin_reg(
         collinear regressors, near-constant windows) return null instead of an arbitrary min-norm
         or explosive coefficient vector — useful for per-group fits, e.g.
         `group_by(...).agg(lin_reg(...))`. The gate fires when the relative determinant
-        `|det(XᵀX)| / Π diag(XᵀX) <= singular_x_tol`, a scale-invariant rank check. The default
-        `1e-12` only catches numerically singular designs; pass `0.0` to disable the gate
-        entirely (restoring the pre-gate behavior of always returning a finite solution).
+        `|det(XᵀX)| / Π diag(XᵀX) <= singular_x_tol`, a scale-invariant rank check. The metric
+        is evaluated in log-space (overflow-safe) and reuses the solver's own factorization;
+        a non-positive `diag(XᵀX)` (zero-variance column) is always gated. The default (`None`)
+        is dtype-aware — `1e-12` for f64 and `1e-6` for f32, since f32 cannot resolve a relative
+        determinant below its machine epsilon (~1e-7). Pass `0.0` to disable the gate entirely
+        (restoring the pre-gate behavior of always returning a finite solution).
     """
 
     if cfg.LIN_REG_EXPR_F64:
         dtype = pl.Float64
     else:
         dtype = pl.Float32
+
+    if singular_x_tol is None:
+        # f32 can't resolve below ~machine eps (1e-7); use a coarser singular floor.
+        singular_x_tol = 1e-12 if cfg.LIN_REG_EXPR_F64 else 1e-6
 
     if isinstance(target, list):
         n_targets = len(target)

--- a/python/polars_ds/exprs/expr_linear.py
+++ b/python/polars_ds/exprs/expr_linear.py
@@ -115,6 +115,7 @@ def lin_reg(
     max_iter: int = 200,
     null_policy: NullPolicy = "skip",
     positive: bool = False,
+    singular_x_tol: float = 1e-12,
 ) -> pl.Expr:
     """
     Computes linear regression solution to the equation Ax = y where y is the target (or multiple targets).
@@ -161,6 +162,15 @@ def lin_reg(
         columns. If this is multi-target, fill will fail if there are nulls in any of the targets.
     positive
         If true, this will perform non-negative linear regression. Not used in multi-target case.
+    singular_x_tol
+        Rank-deficiency gate for ordinary/ridge regression (solver in ['svd', 'qr', 'cholesky'];
+        not used for non-negative, lasso or elastic net). Lets degenerate designs (perfectly
+        collinear regressors, near-constant windows) return null instead of an arbitrary min-norm
+        or explosive coefficient vector — useful for per-group fits, e.g.
+        `group_by(...).agg(lin_reg(...))`. The gate fires when the relative determinant
+        `|det(XᵀX)| / Π diag(XᵀX) <= singular_x_tol`, a scale-invariant rank check. The default
+        `1e-12` only catches numerically singular designs; pass `0.0` to disable the gate
+        entirely (restoring the pre-gate behavior of always returning a finite solution).
     """
 
     if cfg.LIN_REG_EXPR_F64:
@@ -184,6 +194,7 @@ def lin_reg(
                 tol=tol,
                 solver=solver,
                 null_policy=null_policy,
+                singular_x_tol=singular_x_tol,
             )
         else:
             cols = [lr_formula(t).alias(f"target_{i}").cast(dtype) for i, t in enumerate(target)]
@@ -193,6 +204,7 @@ def lin_reg(
                 "solver": solver,
                 "last_target_idx": n_targets,
                 "l2_reg": l2_reg,
+                "singular_x_tol": singular_x_tol,
             }
             cols.extend(lr_formula(z) for z in x)
             if return_pred:
@@ -225,6 +237,7 @@ def lin_reg(
             "max_iter": max_iter,
             "weighted": weighted,
             "positive": positive,
+            "singular_x_tol": singular_x_tol,
         }
 
         if weighted:

--- a/src/linear/lr/lr_solvers.rs
+++ b/src/linear/lr/lr_solvers.rs
@@ -303,26 +303,24 @@ pub fn faer_solve_lr<T: RealField + Float>(
     solve_xtx_xty(xtx, build_xty(x, y), how)
 }
 
-/// Relative determinant of X'X: |det(X'X)| / Π diag(X'X). Scale-invariant rank
-/// check, ~1.0 for well-conditioned designs and ~0 for (near-)singular ones.
+/// Σ ln(v) (or Σ ln|v|) over an iterator. A zero element yields -inf, which makes
+/// the rank gate fire — no special-casing needed.
 #[inline(always)]
-fn rel_det<T: RealField + Float>(xtx: &Mat<T>) -> T {
-    let det: T = xtx.as_ref().determinant().abs();
-    let dprod = xtx
-        .diagonal()
-        .column_vector()
-        .iter()
-        .copied()
-        .fold(T::one(), |acc, d| acc * d);
-    if dprod > T::zero() {
-        det / dprod
-    } else {
-        T::zero()
-    }
+fn sum_ln<T: RealField + Float>(vals: impl Iterator<Item = T>, abs: bool) -> T {
+    vals.fold(T::zero(), |acc, v| {
+        acc + if abs { v.abs().ln() } else { v.ln() }
+    })
 }
 
 /// Like `faer_solve_lr` but returns `None` when the design is rank-deficient, i.e.
-/// `rel_det(X'X) <= tol`. Builds X'X once and skips the X'y build + solve when gated.
+/// the relative determinant `|det(X'X)| / Π diag(X'X) <= tol`.
+///
+/// The metric is evaluated in log-space — `ln|det| - Σ ln(diag)` — which is
+/// overflow-safe (the raw products overflow in f32 for a handful of large-scale
+/// features) and reuses the factorization the solver already needs: `|det(X'X)|`
+/// comes from the QR R diagonal / SVD singular values / Cholesky L diagonal, so no
+/// separate `determinant()` factorization is performed. Degenerate groups skip the
+/// X'y build and the solve entirely.
 #[inline(always)]
 pub fn faer_solve_lr_gated<T: RealField + Float>(
     x: MatRef<T>,
@@ -333,10 +331,50 @@ pub fn faer_solve_lr_gated<T: RealField + Float>(
     tol: T,
 ) -> Option<Mat<T>> {
     let xtx = get_xtx_with_lambda(x, lambda, add_bias);
-    if rel_det(&xtx) <= tol {
-        return None;
+
+    // Denominator Σ ln(diag(X'X)). A non-positive diagonal means a zero-variance
+    // column -> degenerate design -> gate (also keeps ln() in the real domain).
+    let mut ln_den = T::zero();
+    for d in xtx.diagonal().column_vector().iter().copied() {
+        if d <= T::zero() {
+            return None;
+        }
+        ln_den = ln_den + d.ln();
     }
-    Some(solve_xtx_xty(xtx, build_xty(x, y), how))
+    let ln_tol = tol.ln();
+
+    // ln(rel_det) = ln|det(X'X)| - Σ ln(diag). Gate when rel_det <= tol.
+    match how {
+        LRSolverMethods::QR => {
+            let qr = xtx.col_piv_qr();
+            let ln_det = sum_ln(qr.R().diagonal().column_vector().iter().copied(), true);
+            if ln_det - ln_den <= ln_tol {
+                return None;
+            }
+            Some(qr.solve(build_xty(x, y)))
+        }
+        LRSolverMethods::SVD => {
+            // SVD failure -> treat as rank-deficient.
+            let svd = xtx.thin_svd().ok()?;
+            let ln_det = sum_ln(svd.S().column_vector().iter().copied(), false);
+            if ln_det - ln_den <= ln_tol {
+                return None;
+            }
+            Some(svd.solve(build_xty(x, y)))
+        }
+        LRSolverMethods::Choleskey => match xtx.llt(Side::Lower) {
+            // Not positive-definite -> rank-deficient.
+            Err(_) => None,
+            Ok(llt) => {
+                // det(X'X) = Π L_ii^2  ->  ln|det| = 2 Σ ln(L_ii).
+                let s = sum_ln(llt.L().diagonal().column_vector().iter().copied(), false);
+                if (s + s) - ln_den <= ln_tol {
+                    return None;
+                }
+                Some(llt.solve(build_xty(x, y)))
+            }
+        },
+    }
 }
 
 /// Solves the weighted least square with weights given by the user

--- a/src/linear/lr/lr_solvers.rs
+++ b/src/linear/lr/lr_solvers.rs
@@ -234,15 +234,27 @@ pub fn faer_solve_lr_rcond<T: RealField + Float>(
             let max_singular_value = singular_values[0]; // at least 1.
                                                          // singular_values.iter().copied().fold(T::min_value(), T::max);
             let threshold = rcond * max_singular_value;
-            // Safe, because i <= n
-            let mut s_inv = Mat::<T>::zeros(n, n);
+            // Reassociated right-to-left: V * (S^-1 .* (U^T * (X^T y))). Algebraically
+            // identical to V * S^-1 * U^T * X^T * y but avoids the dense n x n S^-1 and
+            // the k x n intermediate of the left-associative form (O(n*k) vs O(n*k^2)).
+            let sinv: Vec<T> = s
+                .iter()
+                .copied()
+                .map(|v| if v >= threshold { v.recip() } else { T::zero() })
+                .collect();
+            let mut z = svd.U().transpose() * build_xty(x, y); // n x yc
+            let yc = z.ncols();
+            // Safe: i < n == z.nrows(), j < yc == z.ncols().
             unsafe {
-                for (i, v) in s.iter().copied().enumerate() {
-                    *s_inv.get_mut_unchecked(i, i) =
-                        if v >= threshold { v.recip() } else { T::zero() };
+                for i in 0..n {
+                    let si = sinv[i];
+                    for j in 0..yc {
+                        let cur = *z.get_mut_unchecked(i, j);
+                        *z.get_mut_unchecked(i, j) = cur * si;
+                    }
                 }
             }
-            let weights = svd.V() * s_inv * svd.U().transpose() * x.transpose() * y;
+            let weights = svd.V() * z;
             Ok((weights, singular_values))
         }
         _ => Err("SVD failed.".to_string()),

--- a/src/linear/lr/lr_solvers.rs
+++ b/src/linear/lr/lr_solvers.rs
@@ -249,17 +249,9 @@ pub fn faer_solve_lr_rcond<T: RealField + Float>(
     }
 }
 
-/// Returns the coefficients for lstsq with l2 (Ridge) regularization as a nrows x 1 matrix
-/// If lambda is 0, then this is the regular lstsq
+/// Builds X'y as an ncols x y.ncols() matrix, parallelizing the matmul above a threshold.
 #[inline(always)]
-pub fn faer_solve_lr<T: RealField + Float>(
-    x: MatRef<T>,
-    y: MatRef<T>,
-    lambda: T,
-    add_bias: bool,
-    how: LRSolverMethods,
-) -> Mat<T> {
-    let xtx = get_xtx_with_lambda(x, lambda, add_bias);
+fn build_xty<T: RealField + Float>(x: MatRef<T>, y: MatRef<T>) -> Mat<T> {
     let mut xty = Mat::zeros(x.ncols(), y.ncols());
     let par = if x.nrows() * y.ncols() < PARALLEL_MATMUL_THRESHOLD {
         Par::Seq
@@ -274,7 +266,16 @@ pub fn faer_solve_lr<T: RealField + Float>(
         T::one(),
         par,
     );
+    xty
+}
 
+/// Solves (X'X) b = X'y for b using the chosen factorization, falling back to QR.
+#[inline(always)]
+fn solve_xtx_xty<T: RealField + Float>(
+    xtx: Mat<T>,
+    xty: Mat<T>,
+    how: LRSolverMethods,
+) -> Mat<T> {
     match how {
         LRSolverMethods::SVD => match xtx.thin_svd() {
             Ok(svd) => svd.solve(xty),
@@ -286,6 +287,56 @@ pub fn faer_solve_lr<T: RealField + Float>(
         },
         LRSolverMethods::QR => xtx.col_piv_qr().solve(xty),
     }
+}
+
+/// Returns the coefficients for lstsq with l2 (Ridge) regularization as a nrows x 1 matrix
+/// If lambda is 0, then this is the regular lstsq
+#[inline(always)]
+pub fn faer_solve_lr<T: RealField + Float>(
+    x: MatRef<T>,
+    y: MatRef<T>,
+    lambda: T,
+    add_bias: bool,
+    how: LRSolverMethods,
+) -> Mat<T> {
+    let xtx = get_xtx_with_lambda(x, lambda, add_bias);
+    solve_xtx_xty(xtx, build_xty(x, y), how)
+}
+
+/// Relative determinant of X'X: |det(X'X)| / Π diag(X'X). Scale-invariant rank
+/// check, ~1.0 for well-conditioned designs and ~0 for (near-)singular ones.
+#[inline(always)]
+fn rel_det<T: RealField + Float>(xtx: &Mat<T>) -> T {
+    let det: T = xtx.as_ref().determinant().abs();
+    let dprod = xtx
+        .diagonal()
+        .column_vector()
+        .iter()
+        .copied()
+        .fold(T::one(), |acc, d| acc * d);
+    if dprod > T::zero() {
+        det / dprod
+    } else {
+        T::zero()
+    }
+}
+
+/// Like `faer_solve_lr` but returns `None` when the design is rank-deficient, i.e.
+/// `rel_det(X'X) <= tol`. Builds X'X once and skips the X'y build + solve when gated.
+#[inline(always)]
+pub fn faer_solve_lr_gated<T: RealField + Float>(
+    x: MatRef<T>,
+    y: MatRef<T>,
+    lambda: T,
+    add_bias: bool,
+    how: LRSolverMethods,
+    tol: T,
+) -> Option<Mat<T>> {
+    let xtx = get_xtx_with_lambda(x, lambda, add_bias);
+    if rel_det(&xtx) <= tol {
+        return None;
+    }
+    Some(solve_xtx_xty(xtx, build_xty(x, y), how))
 }
 
 /// Solves the weighted least square with weights given by the user

--- a/src/num_ext/linear_regression.rs
+++ b/src/num_ext/linear_regression.rs
@@ -1,8 +1,8 @@
 use crate::linear::{
     lr::{
         lr_solvers::{
-            faer_coordinate_descent, faer_nn_lr, faer_solve_lr, faer_solve_lr_rcond,
-            faer_weighted_lr,
+            faer_coordinate_descent, faer_nn_lr, faer_solve_lr, faer_solve_lr_gated,
+            faer_solve_lr_rcond, faer_weighted_lr,
         },
         LRMethods,
     },
@@ -40,6 +40,8 @@ pub(crate) struct LRKwargs {
     pub(crate) positive: bool,
     #[serde(default)]
     pub(crate) max_iter: usize,
+    #[serde(default)]
+    pub(crate) singular_x_tol: f64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -49,6 +51,8 @@ pub(crate) struct MultiLRKwargs {
     pub(crate) solver: String,
     pub(crate) last_target_idx: usize,
     pub(crate) l2_reg: f64,
+    #[serde(default)]
+    pub(crate) singular_x_tol: f64,
 }
 
 // Sherman-William-Woodbury (Update, online versions) LRKwargs
@@ -342,6 +346,72 @@ fn series_to_mat_for_multi_lr(
 }
 
 // -----------------------------------------------------------------------------------------------------
+// Null outputs for rank-deficient designs (singular_x_tol gate). Generic over the numeric
+// type so the f32 plugin variants reuse them.
+
+/// Single-row list column whose only entry is null.
+pub(crate) fn null_coeffs<T: PolarsNumericType>(
+    name: PlSmallStr,
+    n_features: usize,
+    inner: DataType,
+) -> Series {
+    let mut builder: ListPrimitiveChunkedBuilder<T> =
+        ListPrimitiveChunkedBuilder::new(name, 1, n_features, inner);
+    builder.append_null();
+    builder.finish().into_series()
+}
+
+/// Multi-target analogue of `null_coeffs`: a struct with one null list per target.
+pub(crate) fn null_multi_coeffs<T: PolarsNumericType>(
+    names: &[&PlSmallStr],
+    n_features: usize,
+    inner: DataType,
+) -> PolarsResult<Series> {
+    let columns: Vec<Column> = names
+        .iter()
+        .map(|nm| {
+            let mut builder: ListPrimitiveChunkedBuilder<T> =
+                ListPrimitiveChunkedBuilder::new((*nm).clone(), 1, n_features, inner.clone());
+            builder.append_null();
+            builder.finish().into_column()
+        })
+        .collect();
+    Ok(StructChunked::from_columns("coeffs".into(), 1, &columns)?.into_series())
+}
+
+/// All-null {pred, resid} struct of `n` rows.
+pub(crate) fn null_pred_resid<T: PolarsNumericType>(n: usize) -> PolarsResult<Series> {
+    let mut p_builder: PrimitiveChunkedBuilder<T> = PrimitiveChunkedBuilder::new("pred".into(), n);
+    let mut r_builder: PrimitiveChunkedBuilder<T> = PrimitiveChunkedBuilder::new("resid".into(), n);
+    for _ in 0..n {
+        p_builder.append_null();
+        r_builder.append_null();
+    }
+    let p = p_builder.finish().into_series();
+    let r = r_builder.finish().into_series();
+    Ok(StructChunked::from_series("".into(), n, [&p, &r].into_iter())?.into_series())
+}
+
+/// Multi-target analogue of `null_pred_resid`: 2N all-null columns ({name}_pred/_resid).
+pub(crate) fn null_multi_pred<T: PolarsNumericType>(
+    names: &[&PlSmallStr],
+    nrows: usize,
+) -> PolarsResult<Series> {
+    let mut s: Vec<Column> = Vec::with_capacity(names.len() * 2);
+    for nm in names {
+        let mut p_builder: PrimitiveChunkedBuilder<T> =
+            PrimitiveChunkedBuilder::new(format!("{}_pred", nm).into(), nrows);
+        let mut r_builder: PrimitiveChunkedBuilder<T> =
+            PrimitiveChunkedBuilder::new(format!("{}_resid", nm).into(), nrows);
+        for _ in 0..nrows {
+            p_builder.append_null();
+            r_builder.append_null();
+        }
+        s.push(p_builder.finish().into_column());
+        s.push(r_builder.finish().into_column());
+    }
+    Ok(StructChunked::from_columns("all_preds".into(), nrows, &s)?.into_series())
+}
 
 #[polars_expr(output_type_func=coeff_output)]
 fn pl_lr(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
@@ -376,7 +446,27 @@ fn pl_lr(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
                     kwargs.positive,
                 ) {
                     (LRMethods::Normal | LRMethods::L2, false) => {
-                        faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+                        if kwargs.singular_x_tol > 0.0 {
+                            match faer_solve_lr_gated(
+                                x,
+                                y,
+                                kwargs.l2_reg,
+                                add_bias,
+                                solver,
+                                kwargs.singular_x_tol,
+                            ) {
+                                Some(c) => c,
+                                None => {
+                                    return Ok(null_coeffs::<Float64Type>(
+                                        "coeffs".into(),
+                                        nfeats,
+                                        DataType::Float64,
+                                    ))
+                                }
+                            }
+                        } else {
+                            faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+                        }
                     }
                     (LRMethods::Normal, true) => faer_nn_lr(x, y, add_bias, kwargs.tol, max_iter),
                     (LRMethods::L2, true) => faer_coordinate_descent(
@@ -446,12 +536,30 @@ fn pl_lr_multi(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Series>
 
     let coeffs = match LRMethods::from((0., kwargs.l2_reg)) {
         LRMethods::Normal | LRMethods::L2 => {
-            Ok(faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver))
+            if kwargs.singular_x_tol > 0.0 {
+                match faer_solve_lr_gated(
+                    x,
+                    y,
+                    kwargs.l2_reg,
+                    add_bias,
+                    solver,
+                    kwargs.singular_x_tol,
+                ) {
+                    Some(c) => c,
+                    None => {
+                        return null_multi_coeffs::<Float64Type>(&y_names, nfeats, DataType::Float64)
+                    }
+                }
+            } else {
+                faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+            }
         }
-        _ => Err(PolarsError::ComputeError(
-            "The method is not supported.".into(),
-        )),
-    }?;
+        _ => {
+            return Err(PolarsError::ComputeError(
+                "The method is not supported.".into(),
+            ))
+        }
+    };
 
     let columns: Vec<Column> = y_names
         .into_iter()
@@ -494,12 +602,28 @@ fn pl_lr_multi_pred(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Se
 
     let coeffs = match LRMethods::from((0., kwargs.l2_reg)) {
         LRMethods::Normal | LRMethods::L2 => {
-            Ok(faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver))
+            if kwargs.singular_x_tol > 0.0 {
+                match faer_solve_lr_gated(
+                    x,
+                    y,
+                    kwargs.l2_reg,
+                    add_bias,
+                    solver,
+                    kwargs.singular_x_tol,
+                ) {
+                    Some(c) => c,
+                    None => return null_multi_pred::<Float64Type>(&y_names, nrows),
+                }
+            } else {
+                faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+            }
         }
-        _ => Err(PolarsError::ComputeError(
-            "The method is not supported.".into(),
-        )),
-    }?;
+        _ => {
+            return Err(PolarsError::ComputeError(
+                "The method is not supported.".into(),
+            ))
+        }
+    };
 
     let pred = x * &coeffs;
     let resid = y - &pred;
@@ -601,7 +725,26 @@ fn pl_lr_pred(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
                     kwargs.positive,
                 ) {
                     (LRMethods::Normal | LRMethods::L2, false) => {
-                        faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+                        if kwargs.singular_x_tol > 0.0 {
+                            match faer_solve_lr_gated(
+                                x,
+                                y,
+                                kwargs.l2_reg,
+                                add_bias,
+                                solver,
+                                kwargs.singular_x_tol,
+                            ) {
+                                Some(c) => c,
+                                None => {
+                                    // Match the success path's output length: mask.len() when
+                                    // nulls were present, else nrows (mask is a [true] dummy).
+                                    let out_len = if (!&mask).any() { mask.len() } else { nrows };
+                                    return null_pred_resid::<Float64Type>(out_len);
+                                }
+                            }
+                        } else {
+                            faer_solve_lr(x, y, kwargs.l2_reg, add_bias, solver)
+                        }
                     }
                     (LRMethods::Normal, true) => faer_nn_lr(x, y, add_bias, kwargs.tol, max_iter),
                     (LRMethods::L2, true) => faer_coordinate_descent(

--- a/src/num_ext/linear_regression_f32.rs
+++ b/src/num_ext/linear_regression_f32.rs
@@ -6,12 +6,15 @@
 /// Most dtype casting is implicitly handled by the series_to_mat_for_lr function,
 /// but there are some exceptions, mainly from functions with weights. In those cases,
 /// a manual cast need to be used before calling .f64() or .f32() on the series.
-use super::linear_regression::{LRKwargs, MultiLRKwargs, SWWLRKwargs, StandardError};
+use super::linear_regression::{
+    null_coeffs, null_multi_coeffs, null_multi_pred, null_pred_resid, LRKwargs, MultiLRKwargs,
+    SWWLRKwargs, StandardError,
+};
 use crate::linear::{
     lr::{
         lr_solvers::{
-            faer_coordinate_descent, faer_nn_lr, faer_solve_lr, faer_solve_lr_rcond,
-            faer_weighted_lr,
+            faer_coordinate_descent, faer_nn_lr, faer_solve_lr, faer_solve_lr_gated,
+            faer_solve_lr_rcond, faer_weighted_lr,
         },
         LRMethods,
     },
@@ -312,7 +315,27 @@ fn pl_lr_f32(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
                     kwargs.positive,
                 ) {
                     (LRMethods::Normal | LRMethods::L2, false) => {
-                        faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+                        if kwargs.singular_x_tol > 0.0 {
+                            match faer_solve_lr_gated(
+                                x,
+                                y,
+                                kwargs.l2_reg as f32,
+                                add_bias,
+                                solver,
+                                kwargs.singular_x_tol as f32,
+                            ) {
+                                Some(c) => c,
+                                None => {
+                                    return Ok(null_coeffs::<Float32Type>(
+                                        "coeffs".into(),
+                                        nfeats,
+                                        DataType::Float32,
+                                    ))
+                                }
+                            }
+                        } else {
+                            faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+                        }
                     }
                     (LRMethods::Normal, true) => faer_nn_lr(x, y, add_bias, kwargs.tol as f32, 200),
                     (LRMethods::L2, true) => faer_coordinate_descent(
@@ -382,12 +405,30 @@ fn pl_lr_multi_f32(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResult<Ser
 
     let coeffs = match LRMethods::from((0., kwargs.l2_reg)) {
         LRMethods::Normal | LRMethods::L2 => {
-            Ok(faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver))
+            if kwargs.singular_x_tol > 0.0 {
+                match faer_solve_lr_gated(
+                    x,
+                    y,
+                    kwargs.l2_reg as f32,
+                    add_bias,
+                    solver,
+                    kwargs.singular_x_tol as f32,
+                ) {
+                    Some(c) => c,
+                    None => {
+                        return null_multi_coeffs::<Float32Type>(&y_names, nfeats, DataType::Float32)
+                    }
+                }
+            } else {
+                faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+            }
         }
-        _ => Err(PolarsError::ComputeError(
-            "The method is not supported.".into(),
-        )),
-    }?;
+        _ => {
+            return Err(PolarsError::ComputeError(
+                "The method is not supported.".into(),
+            ))
+        }
+    };
 
     let columns: Vec<Column> = y_names
         .into_iter()
@@ -425,12 +466,28 @@ fn pl_lr_multi_pred_f32(inputs: &[Series], kwargs: MultiLRKwargs) -> PolarsResul
 
     let coeffs = match LRMethods::from((0., kwargs.l2_reg)) {
         LRMethods::Normal | LRMethods::L2 => {
-            Ok(faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver))
+            if kwargs.singular_x_tol > 0.0 {
+                match faer_solve_lr_gated(
+                    x,
+                    y,
+                    kwargs.l2_reg as f32,
+                    add_bias,
+                    solver,
+                    kwargs.singular_x_tol as f32,
+                ) {
+                    Some(c) => c,
+                    None => return null_multi_pred::<Float32Type>(&y_names, nrows),
+                }
+            } else {
+                faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+            }
         }
-        _ => Err(PolarsError::ComputeError(
-            "The method is not supported.".into(),
-        )),
-    }?;
+        _ => {
+            return Err(PolarsError::ComputeError(
+                "The method is not supported.".into(),
+            ))
+        }
+    };
 
     let pred = x * &coeffs;
     let resid = y - &pred;
@@ -531,7 +588,26 @@ fn pl_lr_pred_f32(inputs: &[Series], kwargs: LRKwargs) -> PolarsResult<Series> {
                     kwargs.positive,
                 ) {
                     (LRMethods::Normal | LRMethods::L2, false) => {
-                        faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+                        if kwargs.singular_x_tol > 0.0 {
+                            match faer_solve_lr_gated(
+                                x,
+                                y,
+                                kwargs.l2_reg as f32,
+                                add_bias,
+                                solver,
+                                kwargs.singular_x_tol as f32,
+                            ) {
+                                Some(c) => c,
+                                None => {
+                                    // Match the success path's output length: mask.len() when
+                                    // nulls were present, else nrows (mask is a [true] dummy).
+                                    let out_len = if (!&mask).any() { mask.len() } else { nrows };
+                                    return null_pred_resid::<Float32Type>(out_len);
+                                }
+                            }
+                        } else {
+                            faer_solve_lr(x, y, kwargs.l2_reg as f32, add_bias, solver)
+                        }
                     }
                     (LRMethods::Normal, true) => {
                         faer_nn_lr(x, y, add_bias, kwargs.tol as f32, 2000)

--- a/tests/test_linear_exprs.py
+++ b/tests/test_linear_exprs.py
@@ -1245,3 +1245,55 @@ def test_singular_x_tol_multi_target_nulls(lin_reg_dtype):
     )["c"].to_list()[0]
     assert s["target_0"] is None
     assert s["target_1"] is None
+
+
+def _scaled_singular_df(n=2000, feats=7, scale=1e3, seed=3):
+    """Collinear (rank-1) design at large scale: Π diag(X'X) overflows f32."""
+    rng = np.random.default_rng(seed)
+    base = rng.standard_normal(n) * scale
+    cols = {f"x{i}": base * (i + 1) for i in range(feats)}  # all collinear
+    cols["y"] = rng.standard_normal(n) * scale
+    return pl.DataFrame(cols), [f"x{i}" for i in range(feats)]
+
+
+def _scaled_full_rank_df(n=2000, feats=7, scale=1e3, seed=4):
+    """Well-conditioned design at large scale (same overflow regime, full rank)."""
+    rng = np.random.default_rng(seed)
+    cols = {f"x{i}": rng.standard_normal(n) * scale for i in range(feats)}
+    xs = [f"x{i}" for i in range(feats)]
+    df = pl.DataFrame(cols).with_columns(y=sum(pl.col(c) for c in xs))
+    return df, xs
+
+
+def test_singular_x_tol_large_scale_singular_nulls(lin_reg_dtype):
+    # Regression: f32 Π diag(X'X) overflowed -> gate silently failed and returned
+    # finite garbage. The log-space metric must now gate this to null.
+    df, xs = _scaled_singular_df()
+    out = df.select(pds.lin_reg(*xs, target="y", add_bias=False).alias("c"))
+    assert out["c"][0] is None
+
+
+def test_singular_x_tol_large_scale_full_rank_not_nulled(lin_reg_dtype):
+    # No false-null on a well-conditioned large-scale design.
+    df, xs = _scaled_full_rank_df()
+    out = df.select(pds.lin_reg(*xs, target="y", add_bias=False).alias("c"))
+    assert out["c"][0] is not None
+
+
+@pytest.mark.parametrize("solver", ["qr", "svd", "choleskey"])
+def test_singular_x_tol_per_solver(lin_reg_dtype, solver):
+    # Gate works regardless of which factorization the solver uses.
+    sing, xs = _scaled_singular_df()
+    assert (
+        sing.select(
+            pds.lin_reg(*xs, target="y", add_bias=False, solver=solver).alias("c")
+        )["c"][0]
+        is None
+    )
+    full, xs2 = _scaled_full_rank_df()
+    assert (
+        full.select(
+            pds.lin_reg(*xs2, target="y", add_bias=False, solver=solver).alias("c")
+        )["c"][0]
+        is not None
+    )

--- a/tests/test_linear_exprs.py
+++ b/tests/test_linear_exprs.py
@@ -1131,3 +1131,117 @@ def test_lin_reg_null_skip_in_small_group():
 
     for got, exp in zip(out["c"].to_list(), expected):
         np.testing.assert_allclose(got, exp, rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# singular_x_tol: rank-deficiency gate (issue #461)
+# ---------------------------------------------------------------------------
+
+import polars_ds.config as _pds_cfg
+
+
+@pytest.fixture(params=["f64", "f32"])
+def lin_reg_dtype(request, monkeypatch):
+    """Run each gate test under both the f64 and f32 plugin variants."""
+    monkeypatch.setattr(_pds_cfg, "LIN_REG_EXPR_F64", request.param == "f64")
+    return request.param
+
+
+def _collinear_df(n: int = 64, seed: int = 0) -> pl.DataFrame:
+    """A design whose X'X is exactly singular (x2 = 2*x1)."""
+    rng = np.random.default_rng(seed)
+    x1 = rng.standard_normal(n)
+    return pl.DataFrame(
+        {
+            "x1": x1,
+            "x2": 2.0 * x1,  # perfectly collinear -> rank-deficient X'X
+            "y": rng.standard_normal(n),
+        }
+    )
+
+
+def test_singular_x_tol_nulls_collinear_coeffs(lin_reg_dtype):
+    # Default singular_x_tol (1e-12) gates the singular design to null.
+    df = _collinear_df()
+    out = df.select(pds.lin_reg("x1", "x2", target="y", add_bias=False).alias("coeffs"))
+    assert out["coeffs"][0] is None
+
+
+def test_singular_x_tol_off_returns_finite(lin_reg_dtype):
+    # singular_x_tol=0.0 disables the gate -> finite (min-norm) solution as before.
+    df = _collinear_df()
+    out = df.select(
+        pds.lin_reg("x1", "x2", target="y", add_bias=False, singular_x_tol=0.0).alias("coeffs")
+    )
+    coeffs = out["coeffs"][0]
+    assert coeffs is not None
+    assert len(coeffs.to_list()) == 2
+
+
+def test_singular_x_tol_well_conditioned_unchanged(lin_reg_dtype):
+    # A well-conditioned design must NOT be gated and must match sklearn.
+    pytest.importorskip("sklearn")
+    from sklearn.linear_model import LinearRegression
+
+    rng = np.random.default_rng(7)
+    n = 500
+    df = pl.DataFrame(
+        {
+            "x1": rng.standard_normal(n),
+            "x2": rng.standard_normal(n),
+            "x3": rng.standard_normal(n),
+        }
+    ).with_columns(y=pl.col("x1") - 0.5 * pl.col("x2") + 2.0 * pl.col("x3"))
+
+    coeffs = df.select(
+        pds.lin_reg("x1", "x2", "x3", target="y", add_bias=False).alias("c")
+    )["c"][0]
+    assert coeffs is not None
+
+    X = df.select("x1", "x2", "x3").to_numpy()
+    y = df["y"].to_numpy()
+    ref = LinearRegression(fit_intercept=False).fit(X, y).coef_
+    tol = 1e-4 if lin_reg_dtype == "f32" else 1e-9
+    np.testing.assert_allclose(coeffs.to_list(), ref, rtol=tol, atol=tol)
+
+
+def test_singular_x_tol_group_by_nulls_degenerate_group(lin_reg_dtype):
+    # The use case: one degenerate group nulls, the good group fits.
+    rng = np.random.default_rng(11)
+    n = 40
+    good_x1 = rng.standard_normal(n)
+    bad_x1 = rng.standard_normal(n)
+    df = pl.DataFrame(
+        {
+            "g": ["good"] * n + ["bad"] * n,
+            "x1": np.concatenate([good_x1, bad_x1]),
+            "x2": np.concatenate([rng.standard_normal(n), 2.0 * bad_x1]),  # bad group collinear
+            "y": rng.standard_normal(2 * n),
+        }
+    )
+    res = df.group_by("g", maintain_order=True).agg(
+        pds.lin_reg("x1", "x2", target="y", add_bias=False).alias("c")
+    )
+    cmap = {row[0]: row[1] for row in res.iter_rows()}
+    assert cmap["bad"] is None
+    assert cmap["good"] is not None
+
+
+def test_singular_x_tol_return_pred_nulls(lin_reg_dtype):
+    # return_pred path: a gated group yields all-null pred & resid.
+    df = _collinear_df(n=32)
+    out = df.select(
+        pds.lin_reg("x1", "x2", target="y", add_bias=False, return_pred=True).alias("p")
+    ).unnest("p")
+    assert out["pred"].null_count() == df.height
+    assert out["resid"].null_count() == df.height
+
+
+def test_singular_x_tol_multi_target_nulls(lin_reg_dtype):
+    # multi-target coeffs path: all target fields null on a gated design.
+    df = _collinear_df(n=64).with_columns(y2=pl.col("y") * 0.5 + 1.0)
+    s = df.select(
+        pds.lin_reg("x1", "x2", target=["y", "y2"], add_bias=False).alias("c")
+    )["c"].to_list()[0]
+    assert s["target_0"] is None
+    assert s["target_1"] is None

--- a/tests/test_linear_exprs.py
+++ b/tests/test_linear_exprs.py
@@ -511,6 +511,48 @@ def test_lin_reg_with_rcond():
     assert np.all(np.abs(svs - np_svs) < 1e-10)
 
 
+def test_lin_reg_with_rcond_truncates_singular_value():
+    # Exercises the v < threshold -> 1/s := 0 truncation branch in
+    # faer_solve_lr_rcond (the well-conditioned test above keeps all singular
+    # values, so it never hits truncation under the reassociated solve).
+    rng = np.random.default_rng(123)
+    n = 2000
+    x1 = rng.standard_normal(n)
+    x2 = x1 + rng.standard_normal(n) * 1e-6  # near-collinear -> one tiny eigenvalue
+    x3 = rng.standard_normal(n)
+    df = pl.DataFrame({"x1": x1, "x2": x2, "x3": x3}).with_columns(
+        y=pl.col("x1") + 0.5 * pl.col("x2") - 0.3 * pl.col("x3")
+    )
+    rcond = 1e-3  # truncates the near-collinear direction, keeps the other two
+
+    res = df.select(
+        pds.lin_reg_w_rcond("x1", "x2", "x3", target="y", rcond=rcond).alias("r")
+    ).unnest("r")
+    coeffs = res["coeffs"][0].to_numpy()
+    svs = res["singular_values"][0].to_numpy()
+
+    # Reference: pds rcond uses XtX eigenvalues; threshold = rcond * sqrt(max eig);
+    # pseudo-inverse zeroing eigenvalues below threshold.
+    X = df.select("x1", "x2", "x3").to_numpy()
+    y = df["y"].to_numpy()
+    xtx = X.T @ X
+    evals, evecs = np.linalg.eigh(xtx)
+    thr = rcond * np.sqrt(evals.max())
+    assert (evals < thr).any(), "test must actually truncate a singular value"
+    pinv = sum(
+        (1.0 / ev) * np.outer(vec, vec)
+        for ev, vec in zip(evals, evecs.T)
+        if ev >= thr
+    )
+    w_ref = pinv @ (X.T @ y)
+
+    assert np.all(np.isfinite(coeffs))
+    np.testing.assert_allclose(coeffs, w_ref, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(
+        np.sort(svs)[::-1], np.sqrt(np.sort(evals))[::-1], rtol=1e-6, atol=1e-6
+    )
+
+
 def test_lasso_regression():
     # These tests have bigger precision tolerance because of different stopping criterions
 


### PR DESCRIPTION
## Use case (motivation)

Same JKP-style cross-sectional / rolling-regression workload as #445: for each `(date, country)` or rolling `(stock, window)` bucket I fit a small OLS. Some buckets are **degenerate** — perfectly collinear regressors, or a near-constant window — and today every solver (`cholesky`/`qr`/`svd`) returns a finite but arbitrary min-norm or explosive coefficient vector for them, indistinguishable downstream from a good fit. In a rolling Dimson-β over thousands of stock-windows, those degenerate windows silently pollute the output with garbage betas; the only recourse is to post-hoc inspect `singular_values` from `lin_reg_w_rcond` and gate by hand.

This PR (issue #461) adds an opt-in gate so degenerate designs come back as **null** and can be filtered with a plain `.drop_nulls()` / `.filter(col.is_not_null())`. Bundled in is a solver-side speedup for `lin_reg_w_rcond` that fell out of the same code path.

JKP factor zoo reference: https://github.com/bkelly-lab/jkp-data

## Simple explanation

New `singular_x_tol` parameter on `pds.lin_reg(...)`. When the design is rank-deficient — measured by the relative determinant `|det(XᵀX)| / Π diag(XᵀX)`, a scale-invariant rank check — the fit returns `null` instead of a finite-but-arbitrary solution. The gate is **opt-in by tolerance**: pass `0.0` to disable it entirely and recover the previous always-finite behavior.

The metric is evaluated in **log-space** (`Σ ln|R_ii| − Σ ln diag`, etc.) so it is overflow-safe — the raw `Π diag(XᵀX)` overflows to `inf` in f32 for a handful of large-scale features — and it is read from **the factorization the solver already runs** (QR `R` diagonal / SVD singular values / Cholesky `L` diagonal), so there is **no extra `determinant()` factorization**. Degenerate groups skip the `Xᵀy` build and the solve entirely.

Applies only to ordinary/ridge (`svd`/`qr`/`cholesky`); non-negative, lasso and elastic-net are untouched. Solver math, public API for existing callers, kwargs schema, and numeric output (for `singular_x_tol=0.0`) are all unchanged.

## Results

Apple M-series, polars 1.40.1, release build, median of 25 runs.

**Gate overhead** — the gate is a correctness feature, not a speedup; it must not regress the common path. Machine-normalized against `singular_x_tol=0.0` (gate off), `group_by` 8,000 groups × 40 obs (k=6):

| Workload | gate on (default) | gate off | Δ |
|----------|------------------:|---------:|--:|
| `lin_reg` 8,000 groups × 40 obs | 60.7 ms | 61.8 ms | within noise (single factorization, no extra determinant) |

**Bundled rcond speedup** — `faer_solve_lr_rcond` reassociation, machine-normalized (rcond time / unchanged-OLS-control time, same frame):

| Workload | rcond/ols before → after | rcond abs before → after |
|----------|:------------------------:|:------------------------:|
| `lin_reg_w_rcond` n=500k, k=12 | 1.92 → 0.99 | 26.1 → 7.7 ms (**3.4×**) |
| `lin_reg_w_rcond` n=1M, k=8 | 1.62 → 1.01 | (**2.9×**) |
| `lin_reg_w_rcond` n=200k, k=16 | 1.41 → 1.00 | (**2.3×**) |

rcond now costs the same as a plain OLS solve (ratio ≈ 1.0).

**50/50 tests pass** in `tests/test_linear_exprs.py` (10 new test functions, see Testing).

## Scope

- `lin_reg` ordinary/ridge solve paths only: `pl_lr` / `pl_lr_pred` / `pl_lr_multi` / `pl_lr_multi_pred` and their f32 mirrors. The `Normal | L2` arm now routes through a gated solve when `singular_x_tol > 0`; every other arm (non-negative, lasso, elastic-net, weighted) is unchanged.
- `faer_solve_lr_rcond` (powers `lin_reg_w_rcond`) — solve reassociation only; same coefficients, same singular-value truncation threshold.
- `faer_solve_lr` was split into `build_xty` + `solve_xtx_xty` helpers — behavior-preserving (identical codegen on the existing path).
- Untouched: `recursive_lin_reg`, `rolling_lin_reg`, online LR, GLM, KNN, categorical encoders, PSI, metrics.

## Technical changes and their benefits

### 1. Log-space rel-det gate reusing the solver factorization — `faer_solve_lr_gated`

**What:** New `faer_solve_lr_gated(x, y, lambda, add_bias, how, tol) -> Option<Mat<T>>`. Builds `XᵀX` once, computes `ln|det(XᵀX)| − Σ ln diag(XᵀX)` from the chosen solver's own factorization (QR `R` diagonal, SVD singular values, or Cholesky `L` diagonal — no separate `determinant()` call), and returns `None` when `≤ ln(tol)`. A non-positive diagonal (zero-variance column) or SVD/LLT factorization failure is treated as rank-deficient.

**Motivation:** The naive form `|det| / Π diag` formed both products in the working dtype. In f32 `Π diag` overflows to `inf` for ~7 large-scale features, so a genuinely singular design escaped the gate and returned finite garbage. Log-space is overflow-safe and bit-stable. Reusing the solver's factorization means the gate adds only an `O(k)` ln-sum, not a second `O(k³)` factorization.

**When it matters:** every gated fit (default-on). Verified within benchmark noise of the gate-off path.

### 2. Null output across all four solve paths (f64 + f32)

**What:** `#[serde(default)] singular_x_tol: f64` added to `LRKwargs` and `MultiLRKwargs`. Generic null-emission helpers (`null_coeffs` / `null_multi_coeffs` / `null_pred_resid` / `null_multi_pred`, generic over `PolarsNumericType`) emit a null output that matches the success-path schema for each of the 8 plugin functions: single-target coeffs (`append_null` list), per-row predictions (`{pred, resid}` all-null over the correct row count), multi-target coeff struct (null per target list), multi-target predictions (2N all-null columns).

**Motivation:** Schema must match the non-gated output exactly so `group_by_agg` doesn't error; the prediction paths must null the correct number of rows (the null-policy mask is a `[true]` length-1 dummy when there are no nulls, so the output length is `nrows`, not `mask.len()`, in that case).

### 3. Dtype-aware default

**What:** `singular_x_tol` defaults to `None` in the Python wrapper, resolved to `1e-12` for f64 and `1e-6` for f32.

**Motivation:** f32 cannot resolve a relative determinant below its machine epsilon (~1e-7), so `1e-12` is unreachable there; measured clean separation (singular gates at ≥1e-6, well-conditioned stays finite past 1e-4).

### 4. `faer_solve_lr_rcond` reassociation

**What:** Compute `V * (S⁻¹ .* (Uᵀ * (Xᵀy)))` right-to-left instead of `V * S⁻¹ * Uᵀ * Xᵀ * y` left-to-right. Scale a vector by `1/s` instead of building a dense `k×k` `S⁻¹`.

**Motivation:** The left-associative chain materialized a dense (mostly-zero) `S⁻¹` and a `k×n` intermediate — an `O(n·k²)` chain. Reassociation is `O(n·k)`: algebraically identical (matmul associativity + diagonal-as-elementwise-scaling), and the singular-value truncation threshold is byte-preserved. 2.3–3.4× faster at scale (table above).

## Use case examples

### Pattern A — filter degenerate buckets in `group_by_agg` (the primary target)

```python
# Degenerate windows (collinear regressors / near-constant) come back null and drop out.
betas = (
    df.group_by(["stock", "window"])
      .agg(pds.lin_reg("mkt", "smb", "hml", target="ret", add_bias=True).alias("beta"))
      .filter(pl.col("beta").is_not_null())
)
```

### Pattern B — opt out (previous always-finite behavior)

```python
pds.lin_reg("x1", "x2", target="y", singular_x_tol=0.0)   # gate disabled
```

### Pattern C — predictions / multi-target

```python
# A gated group yields all-null pred & resid (return_pred), or all-null target fields (multi).
pds.lin_reg("x1", "x2", target="y", return_pred=True)
pds.lin_reg("x1", "x2", target=["y1", "y2"])
```

### When the PR does NOT help

- Non-negative / lasso / elastic-net / weighted fits (not gated).
- `recursive_lin_reg` / `rolling_lin_reg` / online LR / GLM.

## Testing

- `pytest tests/test_linear_exprs.py` — **50 passed**.
- 10 new test functions (most under an f64/f32 fixture; per-solver parametrized over qr/svd/cholesky):
  - `test_singular_x_tol_nulls_collinear_coeffs`
  - `test_singular_x_tol_off_returns_finite`
  - `test_singular_x_tol_well_conditioned_unchanged` (vs sklearn)
  - `test_singular_x_tol_group_by_nulls_degenerate_group`
  - `test_singular_x_tol_return_pred_nulls`
  - `test_singular_x_tol_multi_target_nulls`
  - `test_singular_x_tol_large_scale_singular_nulls` (f32 `Π diag` overflow regression)
  - `test_singular_x_tol_large_scale_full_rank_not_nulled`
  - `test_singular_x_tol_per_solver`
  - `test_lin_reg_with_rcond_truncates_singular_value` (exercises the `1/s := 0` branch the existing rcond test never hit; checked vs a pseudo-inverse reference)
- `cargo check --lib` clean (no new warnings); `maturin develop --release` clean.
- rcond speedup measured by a machine-normalized A/B: stash the change, rebuild, benchmark; restore, rebuild, benchmark; compare the rcond/OLS-control ratio (the OLS control path is unchanged, normalizing machine variance).

## Future work / not in this PR

- **Native grouped-aggregation OLS (the big group_by lever).** Profiling shows `group_by(...).agg(lin_reg(...))` is dominated by per-group plugin overhead (~6.8 µs/group: FFI + kwargs deserialize + n×k marshaling + output build), not the solve — the same 1-var OLS via native polars expressions (`simple_lin_reg`) is ~28× faster. Forming `XᵀX`/`Xᵀy` per group via native grouped sums and solving the reduced k×k systems in one pass would close most of that gap. Net-new feature, separate PR.
- **Cholesky default for small well-conditioned systems** (followed up from #445 future work) — measured ~8% over the `qr` default on the small-group path.
- Promoting `singular_x_tol` to the weighted / non-negative paths (would require a non-negativity-safe metric).

## AI assist disclosure

Patches drafted with AI assistance (Claude Opus). The gate metric reuses the existing solver factorizations and the rcond reassociation is an algebraic regrouping of the existing formula — no new mathematics introduced. Proposed micro-optimizations were triaged with adversarial verification before applying; 9 of 10 candidates (including a symmetric-`XᵀX` matmul that regresses on ARM and a ridge-gating "fix" that was a non-bug) were rejected as noise, platform-pessimal, or incorrect, and only the rcond reassociation survived. The f32-overflow escape was reproduced empirically before and after the fix; the rcond speedup was measured by control-normalized A/B.
