### PR TITLE
chore: update ethnum 1.5.2 -> 1.5.3 for Rust nightly compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "polars_ds"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "approx",
  "argmin",


### PR DESCRIPTION
ethnum 1.5.2 fails to compile with recent Rust nightly (1.94+) due to a transmute size mismatch caused by std::num::TryFromIntError changing from 0 bits to 8 bits. ethnum 1.5.3 fixes this by removing the problematic transmute.

The project's version in the Cargo.lock was also bumped as it seemed to lag behind the version in the pyproject.toml. Please let me know if this was not intended.

Closes #464.