### PR TITLE
Add simple mixed effects linear models

### DIFF
--- a/python/polars_ds/linear_models.py
+++ b/python/polars_ds/linear_models.py
@@ -22,7 +22,14 @@ from typing import List, Literal, Tuple
 import numpy as np
 import polars as pl
 
-from polars_ds._polars_ds import PyElasticNet, PyGLM, PyLR, PyOnlineLR
+from polars_ds._polars_ds import (
+    PyElasticNet,
+    PyGLM,
+    PyLR,
+    PyMixedModel,
+    PyOnlineLR,
+    student_t_two_sided_pvalue,
+)
 
 from .typing import LRSolverMethods, NullPolicy, PolarsFrame, TypeAlias
 
@@ -941,3 +948,174 @@ class GLM:
     #         pred = pred + bias
 
     #     return df.with_columns(pred.alias(name))
+
+
+# --------------------------------------------------------------------------------
+
+
+class MixedModel:
+    """
+    A random-intercept linear mixed model, fit via restricted maximum likelihood (REML).
+
+    The form is
+
+        y = X @ beta + Z @ u + e,   u ~ N(0, sigma_g^2 I),   e ~ N(0, sigma_e^2 I)
+
+    where `X` is the fixed-effect design matrix (an intercept column plus the given
+    features) and `Z` is the indicator (dummy) design matrix for `group`, i.e. one
+    random intercept per group level.
+
+    Degrees of freedom for each fixed effect are assigned by containment: effects that
+    are constant within every group level (including the intercept) are tested against
+    the group ("between") stratum, everything else against the residual ("within")
+    stratum. 
+    
+    This implementation mirrors SAS's PROC MIXED for a random-intercept model.
+
+    Examples
+    --------
+    ```python
+    import polars as pl
+    from polars_ds.linear_models import MixedModel
+
+    df = pl.DataFrame(
+        {
+            "y": [...],
+            "x1": [...],
+            "school": [...],
+        }
+    )
+    mm = MixedModel().fit_df(df, features=["x1"], target="y", group="school")
+    print(mm.report())
+    ```
+
+    Wikipedia: https://en.wikipedia.org/wiki/Mixed_model#Definition
+    SAS PROC MIXED: https://go.documentation.sas.com/doc/en/pgmsascdc/9.4_3.4/statug/statug_mixed_syntax01.htm
+    """
+
+    def __init__(self):
+        self.feature_names_in_: List[str] = []
+        self.group_name_in_: str | None = None
+        self._mm = PyMixedModel()
+
+    def is_fit(self) -> bool:
+        return self._mm.is_fit()
+
+    @property
+    def coeffs_(self) -> np.ndarray:
+        return np.asarray(self._mm.coeffs)
+
+    @property
+    def std_errors_(self) -> np.ndarray:
+        return np.asarray(self._mm.std_errors)
+
+    @property
+    def dfs_(self) -> np.ndarray:
+        return np.asarray(self._mm.dfs)
+
+    @property
+    def gamma_(self) -> float:
+        """Variance ratio sigma_g^2 / sigma_e^2 at the REML optimum."""
+        return self._mm.gamma
+
+    @property
+    def resid_variance_(self) -> float:
+        """Residual variance sigma_e^2."""
+        return self._mm.resid_variance
+
+    def __repr__(self) -> str:
+        if not self.is_fit():
+            return "MixedModel (not fitted yet)"
+        return (
+            "MixedModel(Random Intercept, REML)\n"
+            f"Group: {self.group_name_in_}\n"
+            f"Variance ratio (group / residual): {self.gamma_:.6g}\n"
+            f"{self.report()}"
+        )
+
+    def fit_df(
+        self,
+        df: PolarsFrame,
+        features: List[str],
+        target: str,
+        group: str,
+        null_policy: NullPolicy = "skip",
+        max_iter: int = 200,
+        tol: float = 1e-10,
+    ) -> Self:
+        """
+        Fit the random-intercept model on a dataframe.
+
+        Parameters
+        ----------
+        df
+            Frame.
+        features
+            List of strings of fixed-effect column names. Intercept is added.
+        target
+            The target column name.
+        group
+            The column identifying the random-intercept grouping factor.
+        null_policy: Literal['raise', 'skip', 'zero', 'one', 'ignore']
+            One of options shown here.
+        max_iter
+            Max number of iterations used for REML deviance over gamma.
+        tol
+            Convergence tolerance for the search.
+        """
+        df2 = (
+            _handle_nulls_in_df(df.lazy(), features, target, null_policy)
+            .drop_nulls(subset=[group])
+            .select(*features, target, group)
+            .collect()
+        )
+        if null_policy == "raise" and any(df2[c].has_nulls() for c in df2.columns):
+            raise ValueError("Nulls found in Dataframe.")
+
+        y = np.ascontiguousarray(df2.get_column(target).to_numpy().astype(np.float64))
+        n = len(y)
+        X = np.ascontiguousarray(
+            np.column_stack(
+                [np.ones(n)] + [df2.get_column(f).to_numpy().astype(np.float64) for f in features]
+            )
+        )
+
+        codes = np.ascontiguousarray(
+            (df2.get_column(group).to_physical().rank("dense").to_numpy() - 1).astype(np.float64)
+        )
+        n_groups = int(codes.max()) + 1
+
+        between_idx = [0] + [
+            j + 1
+            for j, f in enumerate(features)
+            if df2.n_unique(subset=[group, f]) == df2.n_unique(subset=[group])
+        ]
+
+        self._mm.fit(X, y, codes, n_groups, between_idx, max_iter, tol)
+        self.feature_names_in_ = list(features)
+        self.group_name_in_ = group
+        return self
+
+    def report(self) -> pl.DataFrame:
+        """
+        Returns a Polars dataframe with one row per fixed effect (intercept first),
+        containing the estimate, standard error, containment degrees of freedom,
+        t-value and two-sided p-value.
+        """
+        if not self.is_fit():
+            raise ValueError("Model is not fit yet.")
+
+        t = self.coeffs_ / self.std_errors_
+        pvalues = [
+            student_t_two_sided_pvalue(float(ti), float(dfi)) for ti, dfi in zip(t, self.dfs_)
+        ]
+        return pl.DataFrame(
+            {
+                "effect": ["Intercept"] + self.feature_names_in_,
+                "estimate": self.coeffs_,
+                "std_err": self.std_errors_,
+                "df": self.dfs_,
+                "t": t,
+                "p_value": pvalues,
+            }
+        )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod utils;
 use pyo3::{
     pymodule,
     types::{PyModule, PyModuleMethods},
-    Bound, PyResult, Python,
+    wrap_pyfunction, Bound, PyResult, Python,
 };
 
 #[pymodule]
@@ -22,8 +22,13 @@ fn _polars_ds(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<pymodels::py_lr::PyElasticNet>()?;
     m.add_class::<pymodels::py_lr::PyOnlineLR>()?;
     m.add_class::<pymodels::py_glm::PyGLM>()?;
+    m.add_class::<pymodels::py_mixed::PyMixedModel>()?;
     m.add_class::<pymodels::numpy_faer::PyFaerMat>()?;
     m.add_class::<pymodels::numpy_faer::PyArr>()?;
+    m.add_function(wrap_pyfunction!(
+        pymodels::py_stats::student_t_two_sided_pvalue,
+        m
+    )?)?;
     Ok(())
 }
 

--- a/src/linear/mixed/mod.rs
+++ b/src/linear/mixed/mod.rs
@@ -1,0 +1,272 @@
+#![allow(non_snake_case)]
+//! Random-intercept linear mixed model, fit via restricted maximum likelihood (REML).
+//!
+//! The model is
+//!
+//!     y = X @ beta + Z @ u + e,   u ~ N(0, sigma_g^2 I),   e ~ N(0, sigma_e^2 I)
+//!
+//! where `Z` is the indicator (dummy) design matrix for the grouping factor, i.e. one
+//! random intercept per group level. Estimation profiles the restricted log-likelihood
+//! over the variance ratio `gamma = sigma_g^2 / sigma_e^2` with a golden-section search,
+//! then reports the generalized least squares (GLS) solution for `beta` at the optimum.
+//!
+//! `Z` is never materialized: since `Z' Z = diag(group_count)`, the Woodbury identity
+//! turns every `H^-1 = (I + gamma Z Z')^-1` apply and `slogdet(H)` into an O(n) pass over
+//! group sums, rather than the O(n^3) dense `n x n` inverse this would otherwise require.
+
+use faer::{linalg::solvers::Solve, mat::Mat, prelude::*, MatRef, Side};
+
+pub struct MixedModelResult {
+    pub coeffs: Vec<f64>,
+    pub std_errors: Vec<f64>,
+    pub dfs: Vec<f64>,
+    pub gamma: f64,
+    pub resid_variance: f64,
+}
+
+/// Per-group counts and the `1 / (1 + gamma * count)` terms needed to apply `H^-1`
+/// via Woodbury without ever building `Z` or `H`.
+struct GroupInfo {
+    codes: Vec<usize>,
+    counts: Vec<f64>,
+}
+
+impl GroupInfo {
+    fn new(codes: &[usize], n_groups: usize) -> Self {
+        let mut counts = vec![0.0; n_groups];
+        for &g in codes {
+            counts[g] += 1.0;
+        }
+        GroupInfo {
+            codes: codes.to_vec(),
+            counts,
+        }
+    }
+
+    /// Applies `(I + gamma * Z Z')^-1` to a vector via Woodbury:
+    /// `Hi v = v - gamma * Z (I + gamma Z'Z)^-1 Z' v`, and `Z'Z = diag(counts)`.
+    fn apply_hi(&self, v: &[f64], gamma: f64) -> Vec<f64> {
+        let mut group_sum = vec![0.0; self.counts.len()];
+        for (i, &vi) in v.iter().enumerate() {
+            group_sum[self.codes[i]] += vi;
+        }
+        let scaled: Vec<f64> = group_sum
+            .iter()
+            .zip(self.counts.iter())
+            .map(|(&gs, &cnt)| gamma * gs / (1.0 + gamma * cnt))
+            .collect();
+        v.iter()
+            .enumerate()
+            .map(|(i, &vi)| vi - scaled[self.codes[i]])
+            .collect()
+    }
+
+    fn apply_hi_mat(&self, x: MatRef<f64>, gamma: f64) -> Mat<f64> {
+        let cols: Vec<Vec<f64>> = (0..x.ncols())
+            .map(|j| {
+                let col: Vec<f64> = x.col(j).iter().copied().collect();
+                self.apply_hi(&col, gamma)
+            })
+            .collect();
+        Mat::from_fn(x.nrows(), x.ncols(), |i, j| cols[j][i])
+    }
+
+    /// `sum_g log(1 + gamma * count_g)` == `slogdet(I + gamma * Z Z')`.
+    fn slogdet_h(&self, gamma: f64) -> f64 {
+        self.counts
+            .iter()
+            .map(|&cnt| (1.0 + gamma * cnt).ln())
+            .sum()
+    }
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+fn to_mat(v: &[f64]) -> Mat<f64> {
+    Mat::from_fn(v.len(), 1, |i, _| v[i])
+}
+
+fn to_vec(m: MatRef<f64>) -> Vec<f64> {
+    (0..m.nrows()).map(|i| m[(i, 0)]).collect()
+}
+
+/// Rank of `x` via rank-revealing (column-pivoted) QR: the number of `|R_ii|` no
+/// smaller than `tol * |R_00|`.
+fn matrix_rank(x: MatRef<f64>, tol: f64) -> usize {
+    if x.nrows() == 0 || x.ncols() == 0 {
+        return 0;
+    }
+    let qr = x.col_piv_qr();
+    let r = qr.R();
+    let r00 = r[(0, 0)].abs();
+    if r00 == 0.0 {
+        return 0;
+    }
+    let cutoff = r00 * tol;
+    (0..r.nrows().min(r.ncols()))
+        .take_while(|&i| r[(i, i)].abs() > cutoff)
+        .count()
+}
+
+/// One profiled REML deviance evaluation at a fixed `gamma`, plus everything needed to
+/// finalize `beta` / residual variance once the optimal `gamma` is found.
+struct Profiled {
+    beta: Mat<f64>,
+    resid_var: f64,
+    deviance: f64,
+}
+
+fn profile(x: MatRef<f64>, y: &[f64], info: &GroupInfo, gamma: f64) -> Result<Profiled, String> {
+    let n = x.nrows() as f64;
+    let p = x.ncols() as f64;
+
+    let hix = info.apply_hi_mat(x, gamma);
+    let hiy = info.apply_hi(y, gamma);
+
+    let xt_hi_x = x.transpose() * &hix;
+    let xt_hi_y = x.transpose() * to_mat(&hiy);
+
+    let llt = xt_hi_x
+        .llt(Side::Lower)
+        .map_err(|_| "X'HiX is not positive definite; design may be rank-deficient.".to_string())?;
+    let beta = llt.solve(&xt_hi_y);
+
+    let fitted = x * &beta;
+    let r: Vec<f64> = y
+        .iter()
+        .zip(to_vec(fitted.as_ref()))
+        .map(|(a, b)| a - b)
+        .collect();
+    let hir = info.apply_hi(&r, gamma);
+    let rhir = dot(&r, &hir);
+    let resid_var = rhir / (n - p);
+    if !(resid_var > 0.0) {
+        return Err("Residual variance estimate is non-positive.".to_string());
+    }
+
+    let slogdet_xt_hi_x: f64 = 2.0
+        * llt
+            .L()
+            .diagonal()
+            .column_vector()
+            .iter()
+            .map(|v| v.abs().ln())
+            .sum::<f64>();
+
+    let deviance = (n - p) * resid_var.ln() + info.slogdet_h(gamma) + slogdet_xt_hi_x;
+
+    Ok(Profiled {
+        beta,
+        resid_var,
+        deviance,
+    })
+}
+
+/// Fits a random-intercept model via REML.
+///
+/// `x` is the fixed-effect design (intercept column included), `y` the response,
+/// `group_codes` a dense `0..n_groups` grouping per row, and `between_idx` the column
+/// indices of `x` that are constant within every group level (used for containment
+/// degrees of freedom).
+pub fn fit_reml(
+    x: MatRef<f64>,
+    y: &[f64],
+    group_codes: &[usize],
+    n_groups: usize,
+    between_idx: &[usize],
+    max_iter: usize,
+    tol: f64,
+) -> Result<MixedModelResult, String> {
+    let n = x.nrows();
+    let p = x.ncols();
+    if n != y.len() || n != group_codes.len() {
+        return Err("X, y, and group must have the same number of rows.".to_string());
+    }
+    if n <= p {
+        return Err(
+            "Not enough rows to fit a mixed model with this many fixed effects.".to_string(),
+        );
+    }
+
+    let info = GroupInfo::new(group_codes, n_groups);
+
+    let phi = (5f64.sqrt() - 1.0) / 2.0;
+    let (mut lo, mut hi) = (0.0f64, 1e6f64);
+    let mut c = hi - phi * (hi - lo);
+    let mut e = lo + phi * (hi - lo);
+    let mut fc = profile(x, y, &info, c)?.deviance;
+    let mut fe = profile(x, y, &info, e)?.deviance;
+    for _ in 0..max_iter {
+        if hi - lo < tol {
+            break;
+        }
+        if fc < fe {
+            hi = e;
+            e = c;
+            fe = fc;
+            c = hi - phi * (hi - lo);
+            fc = profile(x, y, &info, c)?.deviance;
+        } else {
+            lo = c;
+            c = e;
+            fc = fe;
+            e = lo + phi * (hi - lo);
+            fe = profile(x, y, &info, e)?.deviance;
+        }
+    }
+    let gamma = (lo + hi) / 2.0;
+
+    let fitted = profile(x, y, &info, gamma)?;
+    let xt_hi_x = x.transpose() * info.apply_hi_mat(x, gamma);
+    let cov = xt_hi_x
+        .llt(Side::Lower)
+        .map_err(|_| "X'HiX is not positive definite at the REML optimum.".to_string())?
+        .solve(Mat::<f64>::identity(p, p));
+
+    let coeffs = to_vec(fitted.beta.as_ref());
+    let std_errors: Vec<f64> = (0..p)
+        .map(|j| (fitted.resid_var * cov[(j, j)]).sqrt())
+        .collect();
+
+    // Containment degrees of freedom: fixed effects constant within every group level
+    // (including the intercept) are tested against the group ("between") stratum,
+    // everything else against the residual ("within") stratum.
+    let rank_tol = 1e-9;
+    let between_cols: Vec<usize> = between_idx.to_vec();
+    let x_between = Mat::from_fn(n, between_cols.len(), |i, j| x[(i, between_cols[j])]);
+    let rank_between = matrix_rank(x_between.as_ref(), rank_tol);
+    let ddf_between = (n_groups as f64) - (rank_between as f64);
+
+    let x_and_z = Mat::from_fn(n, p + n_groups, |i, j| {
+        if j < p {
+            x[(i, j)]
+        } else if group_codes[i] == j - p {
+            1.0
+        } else {
+            0.0
+        }
+    });
+    let rank_combined = matrix_rank(x_and_z.as_ref(), rank_tol);
+    let ddf_within = (n as f64) - (rank_combined as f64);
+
+    let between_set: std::collections::HashSet<usize> = between_cols.into_iter().collect();
+    let dfs: Vec<f64> = (0..p)
+        .map(|j| {
+            if between_set.contains(&j) {
+                ddf_between
+            } else {
+                ddf_within
+            }
+        })
+        .collect();
+
+    Ok(MixedModelResult {
+        coeffs,
+        std_errors,
+        dfs,
+        gamma,
+        resid_variance: fitted.resid_var,
+    })
+}

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 pub mod glm;
 pub mod logistic;
 pub mod lr;
+pub mod mixed;
 pub mod online_lr;
 
 pub enum LinalgErrors {

--- a/src/pymodels/mod.rs
+++ b/src/pymodels/mod.rs
@@ -1,3 +1,5 @@
 pub mod numpy_faer;
 pub mod py_glm;
 pub mod py_lr;
+pub mod py_mixed;
+pub mod py_stats;

--- a/src/pymodels/py_mixed.rs
+++ b/src/pymodels/py_mixed.rs
@@ -1,0 +1,88 @@
+#![allow(non_snake_case)]
+use super::numpy_faer::{PyArr, PyArrRef, PyFaerRef};
+use crate::linear::mixed::fit_reml;
+use pyo3::prelude::*;
+
+#[pyclass(subclass)]
+pub struct PyMixedModel {
+    coeffs: Vec<f64>,
+    std_errors: Vec<f64>,
+    dfs: Vec<f64>,
+    gamma: f64,
+    resid_variance: f64,
+    is_fit: bool,
+}
+
+#[pymethods]
+impl PyMixedModel {
+    #[new]
+    pub fn new() -> Self {
+        PyMixedModel {
+            coeffs: Vec::new(),
+            std_errors: Vec::new(),
+            dfs: Vec::new(),
+            gamma: 0.0,
+            resid_variance: 0.0,
+            is_fit: false,
+        }
+    }
+
+    pub fn is_fit(&self) -> bool {
+        self.is_fit
+    }
+
+    /// Fits a random-intercept model via REML.
+    ///
+    /// `group_codes` is a dense `0..n_groups` grouping per row (as f64, rounded to usize).
+    /// `between_idx` are the column indices of `X` constant within every group level,
+    /// used for containment degrees of freedom.
+    #[pyo3(signature=(X, y, group_codes, n_groups, between_idx, max_iter=200, tol=1e-10))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn fit(
+        &mut self,
+        X: PyFaerRef,
+        y: PyArrRef,
+        group_codes: PyArrRef,
+        n_groups: usize,
+        between_idx: Vec<usize>,
+        max_iter: usize,
+        tol: f64,
+    ) -> PyResult<()> {
+        let codes: Vec<usize> = group_codes.0.iter().map(|v| *v as usize).collect();
+        let result = fit_reml(X.0, y.0, &codes, n_groups, &between_idx, max_iter, tol)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
+        self.coeffs = result.coeffs;
+        self.std_errors = result.std_errors;
+        self.dfs = result.dfs;
+        self.gamma = result.gamma;
+        self.resid_variance = result.resid_variance;
+        self.is_fit = true;
+        Ok(())
+    }
+
+    #[getter]
+    pub fn coeffs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArr>> {
+        Bound::new(py, PyArr(self.coeffs.clone()))
+    }
+
+    #[getter]
+    pub fn std_errors<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArr>> {
+        Bound::new(py, PyArr(self.std_errors.clone()))
+    }
+
+    #[getter]
+    pub fn dfs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArr>> {
+        Bound::new(py, PyArr(self.dfs.clone()))
+    }
+
+    #[getter]
+    pub fn gamma(&self) -> f64 {
+        self.gamma
+    }
+
+    #[getter]
+    pub fn resid_variance(&self) -> f64 {
+        self.resid_variance
+    }
+}

--- a/src/pymodels/py_stats.rs
+++ b/src/pymodels/py_stats.rs
@@ -1,0 +1,11 @@
+use crate::stats_utils::beta::student_t_sf;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Two-sided p-value for a Student's t statistic with `df` degrees of freedom,
+/// via the regularized incomplete beta function.
+#[pyfunction]
+pub fn student_t_two_sided_pvalue(t: f64, df: f64) -> PyResult<f64> {
+    let sf = student_t_sf(t.abs(), df).map_err(PyValueError::new_err)?;
+    Ok((2.0 * sf).clamp(0.0, 1.0))
+}

--- a/tests/test_linear_models.py
+++ b/tests/test_linear_models.py
@@ -269,3 +269,43 @@ def test_glm_convergence_failure():
     coeffs = glm.coeffs()
     assert coeffs is not None
     assert np.all(np.isfinite(coeffs))
+
+
+def test_mixed_model_recovers_fixed_effect():
+    """REML fit basic"""
+    from polars_ds.linear_models import MixedModel
+
+    rng = np.random.RandomState(42)
+    n_groups = 40
+    per_group = 25
+    n = n_groups * per_group
+
+    beta0_true, beta1_true = 1.5, 2.0
+    sigma_g, sigma_e = 1.0, 0.5
+
+    group = np.repeat(np.arange(n_groups), per_group)
+    u = rng.normal(0.0, sigma_g, n_groups)[group]
+    x = rng.normal(0.0, 1.0, n)
+    noise_col = rng.normal(0.0, 1.0, n)
+    e = rng.normal(0.0, sigma_e, n)
+    y = beta0_true + beta1_true * x + u + e
+
+    df = pl.DataFrame({"y": y, "x": x, "noise": noise_col, "group": group})
+
+    mm = MixedModel().fit_df(df, features=["x", "noise"], target="y", group="group")
+    assert mm.is_fit()
+
+    report = mm.report()
+    assert report["effect"].to_list() == ["Intercept", "x", "noise"]
+
+    beta0_hat, beta1_hat, beta_noise_hat = report["estimate"].to_list()
+    assert abs(beta0_hat - beta0_true) < 0.5
+    assert abs(beta1_hat - beta1_true) < 0.2
+
+    p_x = report.filter(pl.col("effect") == "x")["p_value"].item()
+    p_noise = report.filter(pl.col("effect") == "noise")["p_value"].item()
+    assert p_x < 1e-6
+    assert p_noise > 0.05
+
+    assert mm.gamma_ is not None and mm.gamma_ > 0.0
+    assert np.all(mm.dfs_ > 0)


### PR DESCRIPTION
This PR adds mixed effects linear models framework to the extension. I was porting some old SAS code which used `PROC MIXED` and found no great alternative if I wanted to use it in a polars pipeline.

For this PR, it's a class interface to the rust code, so not a pure expression extension. The shape looks pretty much like the other linear model classes.

Also, I'm not a true expert on statistics design, so I did my best to copy the logic over but I would appreciate any further criticism.